### PR TITLE
Update docs for msgspec and uv

### DIFF
--- a/docs/monorepo-development-with-astral-uv.md
+++ b/docs/monorepo-development-with-astral-uv.md
@@ -237,9 +237,9 @@ The canonical command for managing these dependencies is `uv add`. To add a depe
 # CWD: Monorepo root.
 uv add --package my-api fastapi
 
-# ACTION: Add the 'pydantic' library as a dependency to the 'shared-utils' package.
+# ACTION: Add the 'msgspec' library as a dependency to the 'shared-utils' package.
 # CWD: Monorepo root.
-uv add --package shared-utils pydantic
+uv add --package shared-utils msgspec
 ```
 
 This workflow maintains a clean separation of concerns: each package explicitly states what it needs, and the workspace manager (`uv`) ensures that all these needs are met in a consistent and conflict-free manner across the entire repository.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD033 MD001 -->
 # Weaver: Development Roadmap
 
 This document provides a detailed, task-oriented development roadmap for building the `weaver` CLI and its associated `weaverd` daemon, based on the established design specification. It is intended for the implementation team to track progress and coordinate efforts.
@@ -8,13 +9,12 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
 - [ ] **Finalise Project Structure & Dependencies:**
 
-  - [ ] Decide on a monorepo (e.g., using `poetry` or `pdm` with workspace support) to house both `weaver` and `weaverd` packages, simplifying dependency management and versioning.
+  - [ ] Decide on a monorepo and use [uv](./docs/monorepo-development-with-astral-uv.md) for package and environment management.
+  - [ ] Initialise the project with [uv](./docs/monorepo-development-with-astral-uv.md) and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for async socket communication), and `multilspy`.
 
-  - [ ] Initialise the project with `poetry` or `pdm` and add core dependencies: `pydantic`, `typer` (for the CLI), `anyio` (for async socket communication), and `multilspy`.
+- [ ] **Define the API Contract with msgspec:**
 
-- [ ] **Define the API Contract with Pydantic:**
-
-  - [ ] Create a shared internal package (`weaver-schemas` or similar) containing Pydantic `BaseModel` definitions for every JSON object specified in Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`, `ImpactReport`, etc.).
+  - [ ] Create a shared internal package (`weaver-schemas` or similar) containing msgspec `Struct` definitions for every JSON object specified in Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`, `ImpactReport`, etc.).
 
   - [ ] Ensure all models include the `type` discriminator field (`type: Literal['diagnostic'] = 'diagnostic'`) to facilitate easy parsing of the JSONL stream on the client side. These models are the single source of truth for the API.
 
@@ -24,7 +24,7 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
   - [ ] Implement an RPC router that listens on a UNIX domain socket (e.g., `$XDG_RUNTIME_DIR/weaverd-$USER.sock`). Use a library like `jsonrpc-py` or build a simple dispatcher that maps method names to handler functions.
 
-  - [ ] The dispatcher should accept JSON requests, validate them against the Pydantic models, call the corresponding (stubbed) handler, and serialize the Pydantic response model back to JSONL.
+  - [ ] The dispatcher should accept JSON requests, validate them against the msgspec models, call the corresponding (stubbed) handler, and serialize the msgspec response model back to JSONL.
 
   - [ ] Implement a basic `ping` or `project-status` RPC endpoint that returns a hardcoded success response.
 
@@ -36,7 +36,7 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
   - [ ] Implement the daemon auto-start logic. If the client cannot connect to the socket, it should attempt to spawn the `weaverd` process in the background (`subprocess.Popen` with appropriate flags to detach it).
 
-  - [ ] Implement the core RPC client function that connects to the socket, sends a Pydantic-serialised request, and streams the JSONL response directly to `stdout`.
+  - [ ] Implement the core RPC client function that connects to the socket, sends a msgspec-serialised request, and streams the JSONL response directly to `stdout`.
 
   - [ ] Implement the `weaver project-status` command to call the `ping` endpoint on the daemon. A successful run of this command validates the entire communication pipeline.
 
@@ -56,7 +56,7 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
   - [ ] `project-status`: Enhance the stub to query the `LanguageServerManager` for the actual status of each language server (PID, memory, readiness state).
 
-  - [ ] `list-diagnostics`: Implement the handler to call `multilspy`'s `get_diagnostics` method and stream the results, converting them to the `weaver` `Diagnostic` Pydantic model.
+  - [ ] `list-diagnostics`: Implement the handler to call `multilspy`'s `get_diagnostics` method and stream the results, converting them to the `weaver` `Diagnostic` msgspec model.
 
 - [ ] **Implement Orient Commands:**
 
@@ -168,7 +168,7 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
 - [ ] **Implement Schema Generation:**
 
-  - [ ] Add the `weaver --json-schema` command. This will iterate through all Pydantic models and use their `.schema_json()` method to print a complete JSON Schema for the entire API.
+  - [ ] Add the `weaver --json-schema` command. This will iterate through all msgspec models and use their `.schema_json()` method to print a complete JSON Schema for the entire API.
 
 - [ ] **Package for Distribution:**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,8 +9,8 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
 - [ ] **Finalise Project Structure & Dependencies:**
 
-  - [ ] Decide on a monorepo and use [uv](./docs/monorepo-development-with-astral-uv.md) for package and environment management.
-  - [ ] Initialise the project with [uv](./docs/monorepo-development-with-astral-uv.md) and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for async socket communication), and `multilspy`.
+  - [ ] Decide on a monorepo and use [uv](monorepo-development-with-astral-uv.md) for package and environment management.
+  - [ ] Initialise the project with [uv](monorepo-development-with-astral-uv.md) and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for async socket communication), and `multilspy`.
 
 - [ ] **Define the API Contract with msgspec:**
 
@@ -168,7 +168,7 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
 - [ ] **Implement Schema Generation:**
 
-  - [ ] Add the `weaver --json-schema` command. This will iterate through all msgspec models and use their `.schema_json()` method to print a complete JSON Schema for the entire API.
+  - [ ] Add the `weaver --json-schema` command. This will iterate through all msgspec models and call `msgspec.json.schema(Model)` to generate a complete JSON Schema for the entire API, emitting it via `json.dumps`.
 
 - [ ] **Package for Distribution:**
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD033 MD001 -->
 # weaver: A Composable, Semantics‑Aware Interface for AI Coding Agents
 
 *Tag‑line: Bridging the semantic gap between text‑only agents and real codebases, one thread at a time.*
@@ -32,7 +33,7 @@ To address the prohibitive startup latency of language servers, `weaver` employs
 
   - It starts and supervises language servers via `multilspy`.
 
-  - It holds an in-memory semantic index, a file-content overlay cache for transient edits, and a Pydantic-validated RPC dispatcher.
+  - It holds an in-memory semantic index, a file-content overlay cache for transient edits, and a msgspec-validated RPC dispatcher.
 
   - It enforces resource caps (e.g., `SERANA_MAX_RAM_MB`, `SERANA_MAX_CPUS`), returning structured errors when limits are reached.
 
@@ -112,7 +113,8 @@ The command suite is the heart of `weaver`, providing the agent with the tools n
 
 1. **Phase 0 – Scaffolding**:
 
-   - Define all I/O schemas as Pydantic models (see Appendix A).
+   - Define all I/O schemas as msgspec models (see Appendix A).
+   - Use [uv](./docs/monorepo-development-with-astral-uv.md) for environment and dependency management.
 
    - Implement the `asyncio` JSON-RPC router for `weaverd`.
 
@@ -150,7 +152,7 @@ The command suite is the heart of `weaver`, providing the agent with the tools n
 
    - Add cancellation support for long-running jobs.
 
-   - Add a `weaver --json-schema` command to print the Pydantic definitions, for embedding in agent prompts.
+   - Add a `weaver --json-schema` command to print the msgspec definitions, for embedding in agent prompts.
 
 ## IV. Advanced Workflows
 
@@ -212,25 +214,25 @@ A command like `weaver request-user-input <prompt>` could enable hybrid human-in
 
 ## Appendix A. Data Schemas (Excerpt)
 
-The following Pydantic types are the single source of truth for all JSONL I/O. Each has a `type` discriminator for effortless streaming introspection.
+The following msgspec types are the single source of truth for all JSONL I/O. Each has a `type` discriminator for effortless streaming introspection.
 
 ```python
 from typing import Literal, Optional
-from pydantic import BaseModel
+from msgspec import Struct
 
-class Position(BaseModel):
+class Position(Struct):
     line: int  # 0-indexed
     character: int  # UTF-16 code units, 0-indexed
 
-class Range(BaseModel):
+class Range(Struct):
     start: Position
     end: Position
 
-class Location(BaseModel):
+class Location(Struct):
     file: str  # Absolute or workspace-relative path
     range: Range
 
-class Diagnostic(BaseModel):
+class Diagnostic(Struct):
     type: Literal['diagnostic'] = 'diagnostic'
     location: Location
     severity: Literal['Error', 'Warning', 'Info', 'Hint']

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -114,7 +114,7 @@ The command suite is the heart of `weaver`, providing the agent with the tools n
 1. **Phase 0 – Scaffolding**:
 
    - Define all I/O schemas as msgspec models (see Appendix A).
-   - Use [uv](./docs/monorepo-development-with-astral-uv.md) for environment and dependency management.
+   - Use [uv](monorepo-development-with-astral-uv.md) for environment and dependency management.
 
    - Implement the `asyncio` JSON-RPC router for `weaverd`.
 


### PR DESCRIPTION
## Summary
- document msgspec usage instead of Pydantic
- reference uv for package management
- disable markdownlint rules for long lines and HTML in docs

## Testing
- `markdownlint docs/weaver-design.md docs/roadmap.md`
- `nixie docs/weaver-design.md docs/roadmap.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68744e0a1140832280f2a96c503f50d5

## Summary by Sourcery

Replace Pydantic with msgspec throughout the project documentation, add references to uv for package and environment management, and disable markdownlint rules for long lines and HTML in the docs

Documentation:
- Document msgspec usage instead of Pydantic in the design guide and roadmap
- Reference uv for monorepo development, environment, and dependency management
- Disable markdownlint rules MD013, MD033, and MD001 in docs to allow long lines and HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reference the use of `msgspec` instead of `pydantic` for data modeling, validation, and serialization.
  * Revised instructions to recommend the "uv" tool for environment and dependency management.
  * Adjusted example schemas and related commands to reflect the switch to `msgspec`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->