### PR TITLE
Add schemas package

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,9 +14,9 @@ This document provides a detailed, task-oriented development roadmap for buildin
 
 - [ ] **Define the API Contract with msgspec:**
 
-  - [ ] Create a shared internal package (`weaver-schemas` or similar) containing msgspec `Struct` definitions for every JSON object specified in Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`, `ImpactReport`, etc.).
+  - [x] Create a shared internal package (`weaver-schemas` or similar) containing msgspec `Struct` definitions for every JSON object specified in Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`, `ImpactReport`, etc.).
 
-  - [ ] Ensure all models include the `type` discriminator field (`type: Literal['diagnostic'] = 'diagnostic'`) to facilitate easy parsing of the JSONL stream on the client side. These models are the single source of truth for the API.
+  - [x] Ensure all models include the `type` discriminator field (`type: Literal['diagnostic'] = 'diagnostic'`) to facilitate easy parsing of the JSONL stream on the client side. These models are the single source of truth for the API.
 
 - [ ] **Implement the** `weaverd` **Daemon Skeleton:**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ This document provides a detailed, task-oriented development roadmap for buildin
   - [x] Decide on a monorepo and use [uv](monorepo-development-with-astral-uv.md) for package and environment management.
   - [x] Initialise the project with [uv](monorepo-development-with-astral-uv.md) and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for async socket communication), and `multilspy`.
 
-- [ ] **Define the API Contract with msgspec:**
+- [x] **Define the API Contract with msgspec:**
 
   - [x] Create a shared internal package (`weaver-schemas` or similar) containing msgspec `Struct` definitions for every JSON object specified in Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`, `ImpactReport`, etc.).
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -163,6 +163,11 @@ because it offers a clean API and automatic help text generation. Communication
 between the client and daemon will use `anyio` for async socket operations.
 `msgspec` is employed for fast, schema‑validated JSON serialization.
 
+All schemas reside in a dedicated `weaver_schemas` package. Each model defines a
+`type` discriminator field so that JSONL streams can be parsed incrementally
+without external context. This package is the single source of truth for the
+daemon and client API.
+
 `can_connect` uses `anyio.fail_after` to avoid hanging on unresponsive sockets,
 handling common connection errors. The CLI's `check-socket` command reports
 availability of a specified path.

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -163,10 +163,11 @@ because it offers a clean API and automatic help text generation. Communication
 between the client and daemon will use `anyio` for async socket operations.
 `msgspec` is employed for fast, schema‑validated JSON serialization.
 
-All schemas reside in a dedicated `weaver_schemas` package. Each model defines a
-`type` discriminator field so that JSONL streams can be parsed incrementally
-without external context. This package is the single source of truth for the
-daemon and client API.
+All schemas reside in a dedicated `weaver_schemas` package. Models are grouped
+into modules by feature (diagnostics, edits, reports, etc.) and each struct
+explicitly defines a `type` discriminator field. This arrangement allows JSONL
+streams to be parsed incrementally without external context and serves as the
+single source of truth for the daemon and client API.
 
 `can_connect` uses `anyio.fail_after` to avoid hanging on unresponsive sockets,
 handling common connection errors. The CLI's `check-socket` command reports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 [tool.pyright]
 pythonVersion = "3.13"
 typeCheckingMode = "strict"
-include = ["weaver"]
+include = ["weaver", "weaver_schemas"]
 
 [tool.ruff]
 line-length = 88
@@ -97,4 +97,7 @@ package = true
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["weaver", "weaver.*", "weaver_schemas", "weaver_schemas.*"]
 

--- a/weaver/unittests/test_schemas.py
+++ b/weaver/unittests/test_schemas.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import typing as t
+
+import pytest
 from msgspec import json
 
 from weaver_schemas import (
@@ -29,7 +32,7 @@ def test_diagnostic_roundtrip() -> None:
 def test_codeedit_roundtrip() -> None:
     edit = CodeEdit(
         file="foo.py",
-        range=Range(Position(1, 0), Position(1, 1)),
+        range=Range(start=Position(1, 0), end=Position(1, 1)),
         new_text="bar",
     )
     data = json.encode(edit)
@@ -44,5 +47,43 @@ def test_impact_report_roundtrip() -> None:
 
 def test_test_result_roundtrip() -> None:
     result = SchemaTestResult(name="pytest", status="passed", output="ok")
+    data = json.encode(result)
+    assert json.decode(data, type=SchemaTestResult) == result
+
+
+def test_impact_report_empty_list() -> None:
+    report = ImpactReport(diagnostics=[])
+    data = json.encode(report)
+    assert json.decode(data, type=ImpactReport) == report
+
+
+def test_test_result_none_output() -> None:
+    result = SchemaTestResult(name="pytest", status="failed", output=None)
+    data = json.encode(result)
+    assert json.decode(data, type=SchemaTestResult) == result
+
+
+@pytest.mark.parametrize("severity", ["Error", "Warning", "Info", "Hint"])
+def test_diagnostic_severity_roundtrip(
+    severity: t.Literal["Error", "Warning", "Info", "Hint"],
+) -> None:
+    diag = Diagnostic(
+        location=Location(
+            file="foo.py",
+            range=Range(start=Position(2, 0), end=Position(2, 1)),
+        ),
+        severity=severity,
+        code=None,
+        message="msg",
+    )
+    data = json.encode(diag)
+    assert json.decode(data, type=Diagnostic) == diag
+
+
+@pytest.mark.parametrize("status", ["passed", "failed", "error", "skipped"])
+def test_test_result_status_roundtrip(
+    status: t.Literal["passed", "failed", "error", "skipped"],
+) -> None:
+    result = SchemaTestResult(name="pytest", status=status)
     data = json.encode(result)
     assert json.decode(data, type=SchemaTestResult) == result

--- a/weaver/unittests/test_schemas.py
+++ b/weaver/unittests/test_schemas.py
@@ -2,21 +2,47 @@ from __future__ import annotations
 
 from msgspec import json
 
-from weaver_schemas import Diagnostic, Location, Position, Range
+from weaver_schemas import (
+    CodeEdit,
+    Diagnostic,
+    ImpactReport,
+    Location,
+    Position,
+    Range,
+)
+from weaver_schemas import (
+    TestResult as SchemaTestResult,
+)
 
 
-def make_example() -> Diagnostic:
+def make_diagnostic() -> Diagnostic:
     loc = Location(file="foo.py", range=Range(start=Position(1, 0), end=Position(1, 3)))
     return Diagnostic(location=loc, severity="Error", code="E123", message="oh no")
 
 
-def test_json_roundtrip() -> None:
-    diagnostic = make_example()
-    data = json.encode(diagnostic)
-    decoded = json.decode(data, type=Diagnostic)
-    assert decoded == diagnostic
+def test_diagnostic_roundtrip() -> None:
+    diag = make_diagnostic()
+    data = json.encode(diag)
+    assert json.decode(data, type=Diagnostic) == diag
 
 
-def test_make_example() -> None:
-    diag = make_example()
-    assert diag.message == "oh no"
+def test_codeedit_roundtrip() -> None:
+    edit = CodeEdit(
+        file="foo.py",
+        range=Range(Position(1, 0), Position(1, 1)),
+        new_text="bar",
+    )
+    data = json.encode(edit)
+    assert json.decode(data, type=CodeEdit) == edit
+
+
+def test_impact_report_roundtrip() -> None:
+    report = ImpactReport(diagnostics=[make_diagnostic()])
+    data = json.encode(report)
+    assert json.decode(data, type=ImpactReport) == report
+
+
+def test_test_result_roundtrip() -> None:
+    result = SchemaTestResult(name="pytest", status="passed", output="ok")
+    data = json.encode(result)
+    assert json.decode(data, type=SchemaTestResult) == result

--- a/weaver/unittests/test_schemas.py
+++ b/weaver/unittests/test_schemas.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from msgspec import json
+
+from weaver_schemas import Diagnostic, Location, Position, Range
+
+
+def make_example() -> Diagnostic:
+    loc = Location(file="foo.py", range=Range(start=Position(1, 0), end=Position(1, 3)))
+    return Diagnostic(location=loc, severity="Error", code="E123", message="oh no")
+
+
+def test_json_roundtrip() -> None:
+    diagnostic = make_example()
+    data = json.encode(diagnostic)
+    decoded = json.decode(data, type=Diagnostic)
+    assert decoded == diagnostic
+
+
+def test_make_example() -> None:
+    diag = make_example()
+    assert diag.message == "oh no"

--- a/weaver_schemas/__init__.py
+++ b/weaver_schemas/__init__.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import typing as t
+
+from msgspec import Struct
+
+
+class Position(Struct):
+    """A point in a text file."""
+
+    line: int
+    character: int
+
+
+class Range(Struct):
+    """A span of text between two positions."""
+
+    start: Position
+    end: Position
+
+
+class Location(Struct):
+    """A range of text within a file."""
+
+    file: str
+    range: Range
+
+
+class Diagnostic(Struct):
+    """A compiler or linter message."""
+
+    location: Location
+    severity: t.Literal["Error", "Warning", "Info", "Hint"]
+    code: str | None
+    message: str
+    type: t.Literal["diagnostic"] = "diagnostic"
+
+
+class Symbol(Struct):
+    """A named code symbol."""
+
+    name: str
+    kind: str
+    location: Location
+    type: t.Literal["symbol"] = "symbol"
+
+
+class Reference(Struct):
+    """A reference to a symbol."""
+
+    location: Location
+    type: t.Literal["reference"] = "reference"
+
+
+class CodeEdit(Struct):
+    """A text replacement within a file."""
+
+    file: str
+    range: Range
+    new_text: str
+    type: t.Literal["edit"] = "edit"
+
+
+class ImpactReport(Struct):
+    """Result of analysing a proposed change."""
+
+    diagnostics: list[Diagnostic]
+    type: t.Literal["impact"] = "impact"
+
+
+class TestResult(Struct):
+    """Outcome of a project test run."""
+
+    name: str
+    status: t.Literal["passed", "failed", "error", "skipped"]
+    output: str | None = None
+    type: t.Literal["test-result"] = "test-result"
+
+
+class OnboardingReport(Struct):
+    """Information gathered during project onboarding."""
+
+    details: str
+    type: t.Literal["onboarding"] = "onboarding"
+
+
+class Error(Struct):
+    """A structured error message."""
+
+    message: str
+    type: t.Literal["error"] = "error"
+
+
+__all__ = [
+    "CodeEdit",
+    "Diagnostic",
+    "Error",
+    "ImpactReport",
+    "Location",
+    "OnboardingReport",
+    "Position",
+    "Range",
+    "Reference",
+    "Symbol",
+    "TestResult",
+]

--- a/weaver_schemas/__init__.py
+++ b/weaver_schemas/__init__.py
@@ -1,106 +1,24 @@
+"""Shared msgspec models for the weaver API."""
+
 from __future__ import annotations
 
-import typing as t
-
-from msgspec import Struct
-
-
-class Position(Struct):
-    """A point in a text file."""
-
-    line: int
-    character: int
-
-
-class Range(Struct):
-    """A span of text between two positions."""
-
-    start: Position
-    end: Position
-
-
-class Location(Struct):
-    """A range of text within a file."""
-
-    file: str
-    range: Range
-
-
-class Diagnostic(Struct):
-    """A compiler or linter message."""
-
-    location: Location
-    severity: t.Literal["Error", "Warning", "Info", "Hint"]
-    code: str | None
-    message: str
-    type: t.Literal["diagnostic"] = "diagnostic"
-
-
-class Symbol(Struct):
-    """A named code symbol."""
-
-    name: str
-    kind: str
-    location: Location
-    type: t.Literal["symbol"] = "symbol"
-
-
-class Reference(Struct):
-    """A reference to a symbol."""
-
-    location: Location
-    type: t.Literal["reference"] = "reference"
-
-
-class CodeEdit(Struct):
-    """A text replacement within a file."""
-
-    file: str
-    range: Range
-    new_text: str
-    type: t.Literal["edit"] = "edit"
-
-
-class ImpactReport(Struct):
-    """Result of analysing a proposed change."""
-
-    diagnostics: list[Diagnostic]
-    type: t.Literal["impact"] = "impact"
-
-
-class TestResult(Struct):
-    """Outcome of a project test run."""
-
-    name: str
-    status: t.Literal["passed", "failed", "error", "skipped"]
-    output: str | None = None
-    type: t.Literal["test-result"] = "test-result"
-
-
-class OnboardingReport(Struct):
-    """Information gathered during project onboarding."""
-
-    details: str
-    type: t.Literal["onboarding"] = "onboarding"
-
-
-class Error(Struct):
-    """A structured error message."""
-
-    message: str
-    type: t.Literal["error"] = "error"
-
+from .diagnostics import Diagnostic
+from .edits import CodeEdit
+from .error import SchemaError
+from .primitives import Location, Position, Range
+from .references import Reference, Symbol
+from .reports import ImpactReport, OnboardingReport, TestResult
 
 __all__ = [
     "CodeEdit",
     "Diagnostic",
-    "Error",
     "ImpactReport",
     "Location",
     "OnboardingReport",
     "Position",
     "Range",
     "Reference",
+    "SchemaError",
     "Symbol",
     "TestResult",
 ]

--- a/weaver_schemas/diagnostics.py
+++ b/weaver_schemas/diagnostics.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import typing as t
+
+from msgspec import Struct
+
+from .primitives import Location  # noqa: TC001
+
+
+class Diagnostic(Struct):
+    """A compiler or linter message."""
+
+    location: Location
+    severity: t.Literal["Error", "Warning", "Info", "Hint"]
+    code: str | None
+    message: str
+    type: t.Literal["diagnostic"] = "diagnostic"
+
+
+__all__ = ["Diagnostic"]

--- a/weaver_schemas/edits.py
+++ b/weaver_schemas/edits.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import typing as t
+
+from msgspec import Struct
+
+from .primitives import Range  # noqa: TC001
+
+
+class CodeEdit(Struct):
+    """A text replacement within a file."""
+
+    file: str
+    range: Range
+    new_text: str
+    type: t.Literal["edit"] = "edit"
+
+
+__all__ = ["CodeEdit"]

--- a/weaver_schemas/error.py
+++ b/weaver_schemas/error.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import typing as t
+
+from msgspec import Struct
+
+
+class SchemaError(Struct):
+    """A structured error message."""
+
+    message: str
+    type: t.Literal["error"] = "error"
+
+
+__all__ = ["SchemaError"]

--- a/weaver_schemas/primitives.py
+++ b/weaver_schemas/primitives.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from msgspec import Struct
+
+
+class Position(Struct):
+    """A point in a text file."""
+
+    line: int
+    character: int
+
+
+class Range(Struct):
+    """A span of text between two positions."""
+
+    start: Position
+    end: Position
+
+
+class Location(Struct):
+    """A range of text within a file."""
+
+    file: str
+    range: Range
+
+
+__all__ = ["Location", "Position", "Range"]

--- a/weaver_schemas/references.py
+++ b/weaver_schemas/references.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import typing as t
+
+from msgspec import Struct
+
+from .primitives import Location  # noqa: TC001
+
+
+class Symbol(Struct):
+    """A named code symbol."""
+
+    name: str
+    kind: str
+    location: Location
+    type: t.Literal["symbol"] = "symbol"
+
+
+class Reference(Struct):
+    """A reference to a symbol."""
+
+    location: Location
+    type: t.Literal["reference"] = "reference"
+
+
+__all__ = ["Reference", "Symbol"]

--- a/weaver_schemas/reports.py
+++ b/weaver_schemas/reports.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import typing as t
+
+from msgspec import Struct
+
+from .diagnostics import Diagnostic  # noqa: TC001
+
+
+class ImpactReport(Struct):
+    """Result of analysing a proposed change."""
+
+    diagnostics: list[Diagnostic]
+    type: t.Literal["impact"] = "impact"
+
+
+class TestResult(Struct):
+    """Outcome of a project test run."""
+
+    name: str
+    status: t.Literal["passed", "failed", "error", "skipped"]
+    output: str | None = None
+    type: t.Literal["test-result"] = "test-result"
+
+
+class OnboardingReport(Struct):
+    """Information gathered during project onboarding."""
+
+    details: str
+    type: t.Literal["onboarding"] = "onboarding"
+
+
+__all__ = ["ImpactReport", "OnboardingReport", "TestResult"]


### PR DESCRIPTION
## Summary
- define msgspec models in new `weaver_schemas` package
- document schema package design decision
- mark schema tasks done in roadmap
- add tests for schema JSON roundtrip
- update packaging for new module

## Testing
- `ruff check weaver_schemas weaver`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ab4218ec8322a0b076fa728be0e6

## Summary by Sourcery

Introduce a dedicated `weaver_schemas` package containing all msgspec-based API models, integrate it into packaging and type-checking, and update documentation and tests accordingly.

New Features:
- Add `weaver_schemas` package with msgspec Struct definitions for core API models

Enhancements:
- Mark schema-related tasks as complete in the project roadmap

Build:
- Include `weaver_schemas` in setuptools packages and pyright configuration

Documentation:
- Document the dedicated schema package and its design in the design doc
- Update roadmap to reflect completed schema tasks

Tests:
- Add JSON roundtrip tests for schema models to verify serialization and deserialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared package for structured schema definitions used in code analysis, editing, diagnostics, symbols, references, code edits, impact reports, test results, onboarding, and errors.

* **Documentation**
  * Updated documentation to clarify the use of a centralized schema package and marked relevant roadmap items as completed.

* **Tests**
  * Added tests to verify schema serialization and construction integrity.

* **Chores**
  * Updated project configuration to include the new schema package for type checking and packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->