### PR TITLE
Fix docs phrasing and env var names

### DIFF
--- a/.rules/python-generators.md
+++ b/.rules/python-generators.md
@@ -90,6 +90,6 @@ def iter_even_doubles():
 ______________________________________________________________________
 
 **Rule of thumb:** If your `for` loop has multiple branches, mutations, or is
-hard to explain briefly—try rewriting it as a generator.
+difficult to explain briefly—try rewriting it as a generator.
 
 Prefer clear, linear data flows over deeply nested conditionals and loop bodies.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -245,7 +245,7 @@ the agent to adapt to local conventions.*
   - [ ] Add logic to monitor the memory and CPU usage of the daemon and its
     child LSP processes.
 
-  - [ ] If the limits defined by `SERANA_MAX_RAM_MB` or `SERANA_MAX_CPUS` are
+  - [ ] If the limits defined by `WEAVER_MAX_RAM_MB` or `WEAVER_MAX_CPUS` are
     exceeded, the daemon should gracefully reject new requests with a
     structured `Error` object.
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -147,19 +147,19 @@ objects conforming to the schemas defined in Appendix A.
 | Command          | Synopsis                                                                      |
 | ---------------- | ----------------------------------------------------------------------------- |
 | project-status   | Health of daemon & language servers; RAM/CPU usage; protocol version.         |
-| list-diagnostics | [--severity S] [<files…>] Stream Diagnostics for whole workspace or subset.   |
+| list-diagnostics | `[--severity S] [<files…>]` Stream Diagnostics for whole workspace or subset.   |
 | onboard-project  | First-run analysis, populates memories & returns OnboardingReport.            |
 
 ### 2.2 Orient
 
 | Command            | Synopsis                                                                               |
 | ------------------ | -------------------------------------------------------------------------------------- |
-| find-symbol        | [--kind K] <pattern> Search workspace symbols.                                         |
-| get-definition     | <file> <line> <char> Locate definitive declaration.                                    |
-| list-references    | [--include-definition] <file> <line> <char> All uses of symbol at cursor.              |
-| summarise-symbol   | <file> <line> <char> Aggregate hover, docstring, type info.                            |
-| get-call-graph     | `--direction <in\|out>` <file> <line> <char> Show call graph with the chosen direction. |
-| get-type-hierarchy | `--direction <super\|sub>` <file> <line> <char> Show type hierarchy for the symbol.     |
+| find-symbol        | `[--kind K] <pattern>` Search workspace symbols.                                         |
+| get-definition     | `<file> <line> <char>` Locate definitive declaration.                                    |
+| list-references    | [--include-definition] `<file> <line> <char>` All uses of symbol at cursor.              |
+| summarise-symbol   | `<file> <line> <char>` Aggregate hover, docstring, type info.                            |
+| get-call-graph     | `--direction <in\|out>` `<file> <line> <char>` Show call graph with the chosen direction. |
+| get-type-hierarchy | `--direction <super\|sub>` `<file> <line> <char>` Show type hierarchy for the symbol.     |
 | list-memories      | Stream previously stored memory snippets.                                              |
 
 ### 2.3 Decide
@@ -167,7 +167,7 @@ objects conforming to the schemas defined in Appendix A.
 | Command             | Synopsis                                                                              |
 | ------------------- | ------------------------------------------------------------------------------------- |
 | analyse-impact      | `--edit <json>` Dry-run a single CodeEdit; returns ImpactReport.                       |
-| get-code-actions    | <file> <line> <char> Available quick-fixes/refactors.                                 |
+| get-code-actions    | `<file> <line> <char>` Available quick-fixes/refactors.                                 |
 | test                | `[--changed-files \| --all]` Wrapper for project test command; same output contract.   |
 | build               | Wrapper for project build command; same output contract.                              |
 | with-transient-edit | `--file <f> --stdin <cmd …>` Overlay speculative content, run another weaver command.  |
@@ -176,10 +176,10 @@ objects conforming to the schemas defined in Appendix A.
 
 | Command            | Synopsis                                                          |
 | ------------------ | ----------------------------------------------------------------- |
-| rename-symbol      | <file> <line> <char> <new> Generate safe rename plan.             |
+| rename-symbol      | `<file> <line> <char> <new>` Generate safe rename plan.             |
 | apply-edits        | `[--atomic]` Read CodeEdit stream from stdin, write to disk.       |
 | format-code        | `[--stdin] [<files…>]` Emit formatting edits via language server.  |
-| set-active-project | <name> Point daemon at another registered project.                |
+| set-active-project | `<name>` Point daemon at another registered project.                |
 | reload-workspace   | Force re-index after dependency file change.                      |
 
 ## III. Implementation Roadmap

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -64,7 +64,7 @@ employs a client-server model.
   - Enforces resource caps (e.g., `WEAVER_MAX_RAM_MB`, `WEAVER_MAX_CPUS`),
     returning structured errors when limits are reached.
 
-  - Serialises concurrent requests using `asyncio` tasks, supporting
+  - Serializes concurrent requests using `asyncio` tasks, supporting
     cancellation of long-running jobs.
 
 - **The** `weaver` **Client:** This is a lightweight, stateless, and

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD013 MD033 MD001 MD056 -->
+<!-- markdownlint-disable MD013 MD033 MD001 MD056 MD007 MD029 -->
 # weaver: A Composable, Semantics‑Aware Interface for AI Coding Agents
 
 *Tag‑line: Bridging the semantic gap between text‑only agents and real
@@ -14,7 +14,7 @@ pieces.
 
 `weaver` is a command‑line interface (CLI) and long‑running daemon that lets an
 agent work at the level of semantics instead of bytes. It sits on top of the
-Serana toolkit and its multi‑language LSP bridge, turning LSP spaghetti into a
+serena toolkit and its multi‑language LSP bridge, turning LSP spaghetti into a
 crisp, UNIX-native interface.
 
 This document synthesizes the original design sketch with subsequent reviews to
@@ -61,7 +61,7 @@ employs a client-server model.
   - Maintains an in-memory semantic index, a file-content overlay cache for
     transient edits, and a msgspec-validated RPC dispatcher.
 
-  - Enforces resource caps (e.g., `SERANA_MAX_RAM_MB`, `SERANA_MAX_CPUS`),
+  - Enforces resource caps (e.g., `WEAVER_MAX_RAM_MB`, `WEAVER_MAX_CPUS`),
     returning structured errors when limits are reached.
 
   - Serialises concurrent requests using `asyncio` tasks, supporting
@@ -186,57 +186,57 @@ objects conforming to the schemas defined in Appendix A.
 
 1. **Phase 0 – Scaffolding**:
 
-   - Define all I/O schemas as msgspec models (see Appendix A).
-   - Use [uv](monorepo-development-with-astral-uv.md) for environment and
+  - Define all I/O schemas as msgspec models (see Appendix A).
+  - Use [uv](./monorepo-development-with-astral-uv.md) for environment and
      dependency management.
 
-   - Implement the `asyncio` JSON-RPC router for `weaverd`.
+  - Implement the `asyncio` JSON-RPC router for `weaverd`.
 
-   - Build the socket discovery and daemon auto-start logic in the `weaver`
+  - Build the socket discovery and daemon auto-start logic in the `weaver`
      client.
 
 2. **Phase 1 – Observe/Orient Verbs**:
 
-   - Map commands directly onto existing `serena.tools` wrappers.
+  - Map commands directly onto existing `serena.tools` wrappers.
 
-   - Validate functionality with a large, polyglot smoke-test repository.
+  - Validate functionality with a large, polyglot smoke-test repository.
 
 3. **Phase 2 – Decide Verbs**:
 
-   - Implement `analyse-impact` by replaying transient edits into the LSP and
+  - Implement `analyse-impact` by replaying transient edits into the LSP and
      diffing the resulting diagnostics.
 
-   - Implement `build` and `test` wrappers that parse tool output into the
+  - Implement `build` and `test` wrappers that parse tool output into the
      standard `Diagnostic` schema via regex patterns defined in `project.yml`.
 
 4. **Phase 3 – Act Verbs**:
 
-   - Implement atomised file writes for `apply-edits`.
+  - Implement atomized file writes for `apply-edits`.
 
-   - Integrate with Git to ensure operations do not corrupt the work-tree.
+  - Integrate with Git to ensure operations do not corrupt the work-tree.
 
-   - Use the LSP `workspace/applyEdit` request to obtain the refactoring plan
+  - Use the LSP `workspace/applyEdit` request to obtain the refactoring plan
      for `rename-symbol`.
 
 5. **Phase 4 – Memories & Onboarding**:
 
-   - Implement the persistence layer for memories as JSONL files under
+  - Implement the persistence layer for memories as JSONL files under
      `.weaver/memories/`.
 
-   - Develop the static analysis logic for `onboard-project`.
+  - Develop the static analysis logic for `onboard-project`.
 
 6. **Phase 5 – Polishing**:
 
-   - Implement resource limit guardrails in `weaverd`.
+  - Implement resource limit guardrails in `weaverd`.
 
-   - Add cancellation support for long-running jobs.
+  - Add cancellation support for long-running jobs.
 
-   - Add a `weaver --json-schema` command to print the msgspec definitions, for
+  - Add a `weaver --json-schema` command to print the msgspec definitions, for
      embedding in agent prompts.
 
 ## Design Decisions
 
-The project uses [uv](monorepo-development-with-astral-uv.md) for dependency
+The project uses [uv](./monorepo-development-with-astral-uv.md) for dependency
 management and virtual environment creation. The CLI is built with `typer`
 because it offers a clean API and automatic help text generation. Communication
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -156,7 +156,7 @@ objects conforming to the schemas defined in Appendix A.
 | ------------------ | -------------------------------------------------------------------------------------- |
 | find-symbol        | `[--kind K] <pattern>` Search workspace symbols.                                         |
 | get-definition     | `<file> <line> <char>` Locate definitive declaration.                                    |
-| list-references    | [--include-definition] `<file> <line> <char>` All uses of symbol at cursor.              |
+| list-references    | `[--include-definition] <file> <line> <char>` All uses of symbol at cursor.              |
 | summarise-symbol   | `<file> <line> <char>` Aggregate hover, docstring, type info.                            |
 | get-call-graph     | `--direction <in\|out>` `<file> <line> <char>` Show call graph with the chosen direction. |
 | get-type-hierarchy | `--direction <super\|sub>` `<file> <line> <char>` Show type hierarchy for the symbol.     |

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -166,19 +166,19 @@ objects conforming to the schemas defined in Appendix A.
 
 | Command             | Synopsis                                                                              |
 | ------------------- | ------------------------------------------------------------------------------------- |
-| analyse-impact      | --edit <json> Dry-run a single CodeEdit; returns ImpactReport.                        |
+| analyse-impact      | `--edit <json>` Dry-run a single CodeEdit; returns ImpactReport.                       |
 | get-code-actions    | <file> <line> <char> Available quick-fixes/refactors.                                 |
 | test                | `[--changed-files \| --all]` Wrapper for project test command; same output contract.   |
 | build               | Wrapper for project build command; same output contract.                              |
-| with-transient-edit | --file <f> --stdin <cmd …> Overlay speculative content, run another weaver command.   |
+| with-transient-edit | `--file <f> --stdin <cmd …>` Overlay speculative content, run another weaver command.  |
 
 ### 2.4 Act
 
 | Command            | Synopsis                                                          |
 | ------------------ | ----------------------------------------------------------------- |
 | rename-symbol      | <file> <line> <char> <new> Generate safe rename plan.             |
-| apply-edits        | [--atomic] Read CodeEdit stream from stdin, write to disk.        |
-| format-code        | [--stdin] [<files…>] Emit formatting edits via language server.   |
+| apply-edits        | `[--atomic]` Read CodeEdit stream from stdin, write to disk.       |
+| format-code        | `[--stdin] [<files…>]` Emit formatting edits via language server.  |
 | set-active-project | <name> Point daemon at another registered project.                |
 | reload-workspace   | Force re-index after dependency file change.                      |
 


### PR DESCRIPTION
## Summary
- update generator guidance wording
- tweak weaver design docs
  - fix toolkit spelling
  - use WEAVER-prefixed env vars
  - link to uv via relative path
  - use American spelling for atomized writes
  - tidy list indentation and disable extra Markdownlint rules

## Testing
- `markdownlint .rules/python-generators.md docs/weaver-design.md`
- `nixie .rules/python-generators.md docs/weaver-design.md`


------
https://chatgpt.com/codex/tasks/task_e_687cd35297548322907e805ff307f23a

## Summary by Sourcery

Refine documentation wording, environment variable names, and markdown formatting across project docs

Documentation:
- disable additional Markdownlint rules and clean up list indentation in weaver-design.md
- standardize environment variable prefixes to WEAVER_MAX_RAM_MB and WEAVER_MAX_CPUS in design and roadmap docs
- fix toolkit spelling and unify the casing of 'serena'
- switch to American spelling for terms like serialize and atomized
- adjust markdown syntax with inline code formatting for command arguments and use relative link paths
- rephrase generator guidance in python-generators.md for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved wording and consistency in documentation.
  * Updated environment variable prefixes and corrected relative links.
  * Made minor spelling and formatting adjustments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->