### PR TITLE
Implement weaver client skeleton

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,23 +50,23 @@ will be implemented yet.*
   - [x] Implement a basic `ping` or `project-status` RPC endpoint that returns
     a hardcoded success response.
 
-- [ ] **Implement the** `weaver` **Client Skeleton:**
+- [x] **Implement the** `weaver` **Client Skeleton:**
 
-  - [ ] Set up the CLI using `typer`. Create a stub for each command defined in
+  - [x] Set up the CLI using `typer`. Create a stub for each command defined in
     the design document.
 
-  - [ ] Implement the socket discovery logic. The client must locate the
+  - [x] Implement the socket discovery logic. The client must locate the
     `weaverd` socket at its well-known path.
 
-  - [ ] Implement the daemon auto-start logic. If the client cannot connect to
+  - [x] Implement the daemon auto-start logic. If the client cannot connect to
     the socket, it should attempt to spawn the `weaverd` process in the
     background (`subprocess.Popen` with appropriate flags to detach it).
 
-  - [ ] Implement the core RPC client function that connects to the socket,
+  - [x] Implement the core RPC client function that connects to the socket,
     sends a msgspec-serialised request, and streams the JSONL response directly
     to `stdout`.
 
-  - [ ] Implement the `weaver project-status` command to call the `ping`
+  - [x] Implement the `weaver project-status` command to call the `ping`
     endpoint on the daemon. A successful run of this command validates the
     entire communication pipeline.
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -255,7 +255,9 @@ availability of a specified path.
 
 The client auto-starts `weaverd` when the socket is missing. It forks the
 daemon in a detached `subprocess.Popen` call and waits for the socket to
-become available before issuing the request.
+become available before issuing the request. Set the environment variable
+`WEAVER_DEBUG=1` to inherit the daemon's output streams when debugging startup
+failures.
 
 `weaverd` exposes a lightweight RPC interface over a UNIX domain socket. A
 custom `RPCDispatcher` maps method names to coroutine handlers and uses

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -253,6 +253,10 @@ single source of truth for the daemon and client API.
 handling common connection errors. The CLI's `check-socket` command reports
 availability of a specified path.
 
+The client auto-starts `weaverd` when the socket is missing. It forks the
+daemon in a detached `subprocess.Popen` call and waits for the socket to
+become available before issuing the request.
+
 `weaverd` exposes a lightweight RPC interface over a UNIX domain socket. A
 custom `RPCDispatcher` maps method names to coroutine handlers and uses
 `msgspec` to validate requests and serialise responses. The default socket path

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -158,8 +158,8 @@ objects conforming to the schemas defined in Appendix A.
 | get-definition     | <file> <line> <char> Locate definitive declaration.                                    |
 | list-references    | [--include-definition] <file> <line> <char> All uses of symbol at cursor.              |
 | summarise-symbol   | <file> <line> <char> Aggregate hover, docstring, type info.                            |
-| get-call-graph     | `--direction <in\|out>` <file> <line> <char> Show call graph with the chosen direction. |
-| get-type-hierarchy | `--direction <super\|sub>` <file> <line> <char> Show type hierarchy for the symbol.     |
+| get-call-graph     | `--direction <in|out>` <file> <line> <char> Show call graph with the chosen direction. |
+| get-type-hierarchy | `--direction <super|sub>` <file> <line> <char> Show type hierarchy for the symbol.     |
 | list-memories      | Stream previously stored memory snippets.                                              |
 
 ### 2.3 Decide
@@ -168,7 +168,7 @@ objects conforming to the schemas defined in Appendix A.
 | ------------------- | ------------------------------------------------------------------------------------- |
 | analyse-impact      | --edit <json> Dry-run a single CodeEdit; returns ImpactReport.                        |
 | get-code-actions    | <file> <line> <char> Available quick-fixes/refactors.                                 |
-| test                | `[--changed-files \| --all]` Wrapper for project test command; same output contract.   |
+| test                | `[--changed-files | --all]` Wrapper for project test command; same output contract.   |
 | build               | Wrapper for project build command; same output contract.                              |
 | with-transient-edit | --file <f> --stdin <cmd …> Overlay speculative content, run another weaver command.   |
 
@@ -254,8 +254,8 @@ handling common connection errors. The CLI's `check-socket` command reports
 availability of a specified path.
 
 The client auto-starts `weaverd` when the socket is missing. It forks the
-daemon in a detached `subprocess.Popen` call and waits for the socket to
-become available before issuing the request. Set the environment variable
+daemon in a detached `subprocess.Popen` call and waits for the socket to become
+available before issuing the request. Set the environment variable
 `WEAVER_DEBUG=1` to inherit the daemon's output streams when debugging startup
 failures.
 

--- a/features/project_status.feature
+++ b/features/project_status.feature
@@ -1,0 +1,5 @@
+Feature: project status command
+  Scenario: daemon auto-start
+    Given a temporary runtime dir
+    When I invoke the project-status command
+    Then the output includes a project status line

--- a/features/steps/test_project_status.py
+++ b/features/steps/test_project_status.py
@@ -1,0 +1,64 @@
+import asyncio
+import multiprocessing as mp
+import os
+from pathlib import Path
+
+from pytest_bdd import given, scenarios, then, when
+from typer.testing import CliRunner
+
+from weaver import client
+from weaver.cli import app
+from weaver_schemas.status import ProjectStatus
+from weaverd.rpc import RPCDispatcher
+from weaverd.server import start_server
+
+scenarios("../project_status.feature")
+
+
+@given("a temporary runtime dir", target_fixture="runtime_dir")
+def runtime_dir(tmp_path: Path, monkeypatch):
+    os.environ["XDG_RUNTIME_DIR"] = str(tmp_path)
+    sock = client.discover_socket()
+
+    started: dict[str, mp.Process] = {}
+
+    def wrapper(p: Path) -> mp.Process:
+        def _run() -> None:
+            async def _serve() -> None:
+                dispatcher = RPCDispatcher()
+
+                @dispatcher.register("project-status")
+                async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
+                    return ProjectStatus(message="ok")
+
+                server = await start_server(p, dispatcher)
+                async with server:
+                    await server.serve_forever()
+
+            asyncio.run(_serve())
+
+        proc = mp.Process(target=_run)
+        proc.start()
+        started["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(client, "spawn_daemon", wrapper)
+    return {"sock": sock, "proc": started}
+
+
+@when("I invoke the project-status command")
+def invoke(runtime_dir: dict):
+    runner = CliRunner()
+    result = runner.invoke(app, ["project-status"])
+    runtime_dir["result"] = result
+
+
+@then("the output includes a project status line")
+def check(runtime_dir: dict):
+    result = runtime_dir["result"]
+    assert result.exit_code == 0
+    assert "project-status" in result.stdout
+    proc = runtime_dir["proc"].get("proc")
+    if proc:
+        proc.terminate()
+        proc.join()

--- a/features/steps/test_project_status.py
+++ b/features/steps/test_project_status.py
@@ -20,30 +20,37 @@ def runtime_dir(tmp_path: Path, monkeypatch):
     os.environ["XDG_RUNTIME_DIR"] = str(tmp_path)
     sock = client.discover_socket()
 
-    started: dict[str, mp.Process] = {}
+    processes: list[mp.Process] = []
 
     def wrapper(p: Path) -> mp.Process:
         def _run() -> None:
-            async def _serve() -> None:
-                dispatcher = RPCDispatcher()
+            # Use a dedicated event loop for the subprocess
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
 
-                @dispatcher.register("project-status")
-                async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
-                    return ProjectStatus(message="ok")
+                async def _serve() -> None:
+                    dispatcher = RPCDispatcher()
 
-                server = await start_server(p, dispatcher)
-                async with server:
-                    await server.serve_forever()
+                    @dispatcher.register("project-status")
+                    async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
+                        return ProjectStatus(message="ok")
 
-            asyncio.run(_serve())
+                    server = await start_server(p, dispatcher)
+                    async with server:
+                        await server.serve_forever()
+
+                loop.run_until_complete(_serve())
+            finally:
+                loop.close()
 
         proc = mp.Process(target=_run)
         proc.start()
-        started["proc"] = proc
+        processes.append(proc)
         return proc
 
     monkeypatch.setattr(client, "spawn_daemon", wrapper)
-    return {"sock": sock, "proc": started}
+    return {"sock": sock, "processes": processes}
 
 
 @when("I invoke the project-status command")
@@ -57,10 +64,13 @@ def invoke(runtime_dir: dict):
 def check(runtime_dir: dict):
     result = runtime_dir["result"]
     assert result.exit_code == 0
-    assert "project-status" in result.stdout
-    proc = runtime_dir["proc"].get("proc")
-    if proc:
-        proc.terminate()
-        proc.join(timeout=5.0)
-        if proc.is_alive():
-            proc.kill()
+    assert '"message":"ok"' in result.stdout
+    processes = runtime_dir.get("processes", [])
+    for proc in processes:
+        if proc and proc.is_alive():
+            proc.terminate()
+            try:
+                proc.join(timeout=5)
+            finally:
+                if proc.is_alive():
+                    proc.kill()

--- a/features/steps/test_project_status.py
+++ b/features/steps/test_project_status.py
@@ -61,4 +61,6 @@ def check(runtime_dir: dict):
     proc = runtime_dir["proc"].get("proc")
     if proc:
         proc.terminate()
-        proc.join()
+        proc.join(timeout=5.0)
+        if proc.is_alive():
+            proc.kill()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "ruff",
     "pyright",
     "pytest-timeout",
+    "pytest-bdd>=8.1.0",
 ]
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,15 @@ wheels = [
 ]
 
 [[package]]
+name = "gherkin-official"
+version = "29.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -69,6 +78,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -78,6 +99,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393, upload-time = "2024-10-18T15:20:52.426Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732, upload-time = "2024-10-18T15:20:53.578Z" },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866, upload-time = "2024-10-18T15:20:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964, upload-time = "2024-10-18T15:20:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977, upload-time = "2024-10-18T15:20:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366, upload-time = "2024-10-18T15:20:58.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091, upload-time = "2024-10-18T15:20:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065, upload-time = "2024-10-18T15:21:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514, upload-time = "2024-10-18T15:21:01.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload-time = "2024-10-18T15:21:06.495Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload-time = "2024-10-18T15:21:07.295Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload-time = "2024-10-18T15:21:08.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload-time = "2024-10-18T15:21:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload-time = "2024-10-18T15:21:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload-time = "2024-10-18T15:21:11.005Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload-time = "2024-10-18T15:21:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
@@ -144,6 +223,28 @@ wheels = [
 ]
 
 [[package]]
+name = "parse"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/e9/a3b2ae5f8a852542788ac1f1865dcea0c549cc40af243f42cabfa0acf24d/parse_type-0.6.4.tar.gz", hash = "sha256:5e1ec10440b000c3f818006033372939e693a9ec0176f446d9303e4db88489a6", size = 96480, upload-time = "2024-10-03T11:51:00.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/b3/f6cc950042bfdbe98672e7c834d930f85920fb7d3359f59096e8d2799617/parse_type-0.6.4-py2.py3-none-any.whl", hash = "sha256:83d41144a82d6b8541127bf212dd76c7f01baff680b498ce8a4d052a7a5bce4c", size = 27442, upload-time = "2024-10-03T11:50:58.519Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -190,6 +291,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-bdd"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gherkin-official" },
+    { name = "mako" },
+    { name = "packaging" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2f/14c2e55372a5718a93b56aea48cd6ccc15d2d245364e516cd7b19bbd07ad/pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5", size = 56147, upload-time = "2024-12-05T21:45:58.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/7d/1461076b0cc9a9e6fa8b51b9dea2677182ba8bc248d99d95ca321f2c666f/pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb", size = 49149, upload-time = "2024-12-05T21:45:56.184Z" },
 ]
 
 [[package]]
@@ -250,6 +369,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -338,6 +466,7 @@ dependencies = [
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-bdd" },
     { name = "pytest-timeout" },
     { name = "ruff" },
 ]
@@ -353,6 +482,7 @@ requires-dist = [
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-timeout" },
     { name = "ruff" },
 ]

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -6,6 +6,7 @@ import anyio
 import typer
 
 from . import pure
+from .client import rpc_call
 from .sockets import can_connect
 
 app = typer.Typer(name="weaver")
@@ -25,3 +26,110 @@ def check_socket(path: Path) -> None:
         typer.echo(f"socket available: {path}")
     else:
         typer.echo(f"socket unavailable: {path}")
+
+
+def _todo(name: str) -> None:
+    """Placeholder for unimplemented commands."""
+    typer.echo(f"{name} not implemented", err=True)
+    raise typer.Exit(1)
+
+
+@app.command("project-status")
+def project_status() -> None:
+    """Check daemon and language server health."""
+    anyio.run(rpc_call, "project-status")
+
+
+@app.command("list-diagnostics")
+def list_diagnostics() -> None:  # pragma: no cover - stub
+    _todo("list-diagnostics")
+
+
+@app.command("onboard-project")
+def onboard_project() -> None:  # pragma: no cover - stub
+    _todo("onboard-project")
+
+
+@app.command("find-symbol")
+def find_symbol() -> None:  # pragma: no cover - stub
+    _todo("find-symbol")
+
+
+@app.command("get-definition")
+def get_definition() -> None:  # pragma: no cover - stub
+    _todo("get-definition")
+
+
+@app.command("list-references")
+def list_references() -> None:  # pragma: no cover - stub
+    _todo("list-references")
+
+
+@app.command("summarise-symbol")
+def summarise_symbol() -> None:  # pragma: no cover - stub
+    _todo("summarise-symbol")
+
+
+@app.command("get-call-graph")
+def get_call_graph() -> None:  # pragma: no cover - stub
+    _todo("get-call-graph")
+
+
+@app.command("get-type-hierarchy")
+def get_type_hierarchy() -> None:  # pragma: no cover - stub
+    _todo("get-type-hierarchy")
+
+
+@app.command("list-memories")
+def list_memories() -> None:  # pragma: no cover - stub
+    _todo("list-memories")
+
+
+@app.command("analyse-impact")
+def analyse_impact() -> None:  # pragma: no cover - stub
+    _todo("analyse-impact")
+
+
+@app.command("get-code-actions")
+def get_code_actions() -> None:  # pragma: no cover - stub
+    _todo("get-code-actions")
+
+
+@app.command("test")
+def cmd_test() -> None:  # pragma: no cover - stub
+    _todo("test")
+
+
+@app.command("build")
+def cmd_build() -> None:  # pragma: no cover - stub
+    _todo("build")
+
+
+@app.command("with-transient-edit")
+def with_transient_edit() -> None:  # pragma: no cover - stub
+    _todo("with-transient-edit")
+
+
+@app.command("rename-symbol")
+def rename_symbol() -> None:  # pragma: no cover - stub
+    _todo("rename-symbol")
+
+
+@app.command("apply-edits")
+def apply_edits() -> None:  # pragma: no cover - stub
+    _todo("apply-edits")
+
+
+@app.command("format-code")
+def format_code() -> None:  # pragma: no cover - stub
+    _todo("format-code")
+
+
+@app.command("set-active-project")
+def set_active_project() -> None:  # pragma: no cover - stub
+    _todo("set-active-project")
+
+
+@app.command("reload-workspace")
+def reload_workspace() -> None:  # pragma: no cover - stub
+    _todo("reload-workspace")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 from pathlib import Path  # noqa: TC003 -- Typer evaluates this at runtime
 
 import anyio
@@ -34,102 +35,44 @@ def _todo(name: str) -> None:
     raise typer.Exit(1)
 
 
+def _make_stub(name: str) -> t.Callable[[], None]:
+    def command() -> None:  # pragma: no cover - stub
+        _todo(name)
+
+    return command
+
+
 @app.command("project-status")
 def project_status() -> None:
     """Check daemon and language server health."""
-    anyio.run(rpc_call, "project-status")
+    try:
+        anyio.run(rpc_call, "project-status")
+    except Exception as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
 
 
-@app.command("list-diagnostics")
-def list_diagnostics() -> None:  # pragma: no cover - stub
-    _todo("list-diagnostics")
+STUBS = [
+    "list-diagnostics",
+    "onboard-project",
+    "find-symbol",
+    "get-definition",
+    "list-references",
+    "summarise-symbol",
+    "get-call-graph",
+    "get-type-hierarchy",
+    "list-memories",
+    "analyse-impact",
+    "get-code-actions",
+    "test",
+    "build",
+    "with-transient-edit",
+    "rename-symbol",
+    "apply-edits",
+    "format-code",
+    "set-active-project",
+    "reload-workspace",
+]
 
-
-@app.command("onboard-project")
-def onboard_project() -> None:  # pragma: no cover - stub
-    _todo("onboard-project")
-
-
-@app.command("find-symbol")
-def find_symbol() -> None:  # pragma: no cover - stub
-    _todo("find-symbol")
-
-
-@app.command("get-definition")
-def get_definition() -> None:  # pragma: no cover - stub
-    _todo("get-definition")
-
-
-@app.command("list-references")
-def list_references() -> None:  # pragma: no cover - stub
-    _todo("list-references")
-
-
-@app.command("summarise-symbol")
-def summarise_symbol() -> None:  # pragma: no cover - stub
-    _todo("summarise-symbol")
-
-
-@app.command("get-call-graph")
-def get_call_graph() -> None:  # pragma: no cover - stub
-    _todo("get-call-graph")
-
-
-@app.command("get-type-hierarchy")
-def get_type_hierarchy() -> None:  # pragma: no cover - stub
-    _todo("get-type-hierarchy")
-
-
-@app.command("list-memories")
-def list_memories() -> None:  # pragma: no cover - stub
-    _todo("list-memories")
-
-
-@app.command("analyse-impact")
-def analyse_impact() -> None:  # pragma: no cover - stub
-    _todo("analyse-impact")
-
-
-@app.command("get-code-actions")
-def get_code_actions() -> None:  # pragma: no cover - stub
-    _todo("get-code-actions")
-
-
-@app.command("test")
-def cmd_test() -> None:  # pragma: no cover - stub
-    _todo("test")
-
-
-@app.command("build")
-def cmd_build() -> None:  # pragma: no cover - stub
-    _todo("build")
-
-
-@app.command("with-transient-edit")
-def with_transient_edit() -> None:  # pragma: no cover - stub
-    _todo("with-transient-edit")
-
-
-@app.command("rename-symbol")
-def rename_symbol() -> None:  # pragma: no cover - stub
-    _todo("rename-symbol")
-
-
-@app.command("apply-edits")
-def apply_edits() -> None:  # pragma: no cover - stub
-    _todo("apply-edits")
-
-
-@app.command("format-code")
-def format_code() -> None:  # pragma: no cover - stub
-    _todo("format-code")
-
-
-@app.command("set-active-project")
-def set_active_project() -> None:  # pragma: no cover - stub
-    _todo("set-active-project")
-
-
-@app.command("reload-workspace")
-def reload_workspace() -> None:  # pragma: no cover - stub
-    _todo("reload-workspace")
+for name in STUBS:
+    app.command(name)(_make_stub(name))

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import io  # noqa: TC003
+import os
 import subprocess
 import sys
 import typing as t
 from pathlib import Path  # noqa: TC003
 
 import anyio
+import typer
 from msgspec import json
 
 from weaverd.server import default_socket_path
@@ -20,13 +22,17 @@ def discover_socket() -> Path:
     return default_socket_path()
 
 
-def spawn_daemon(socket_path: Path) -> subprocess.Popen[bytes]:
-    """Spawn the ``weaverd`` daemon detached from the controlling terminal."""
+def spawn_daemon(
+    socket_path: Path, *, debug: bool | None = None
+) -> subprocess.Popen[bytes]:
+    """Spawn ``weaverd`` detached from the controlling terminal."""
+    debug_env = os.environ.get("WEAVER_DEBUG", "0")
+    debug = bool(int(debug_env)) if debug is None else debug
     return subprocess.Popen(  # noqa: S603 -- trusted internal command
         [sys.executable, "-m", "weaverd", "--socket-path", str(socket_path)],
         stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=None if debug else subprocess.DEVNULL,
+        stderr=None if debug else subprocess.DEVNULL,
         start_new_session=True,
     )
 
@@ -52,12 +58,22 @@ async def rpc_call(
     """Send an RPC request and stream the response to ``stdout``."""
     path = socket_path or discover_socket()
     stdout = t.cast("t.TextIO", sys.stdout if stdout is None else stdout)
-    await ensure_daemon_running(path)
+    try:
+        await ensure_daemon_running(path)
+    except Exception as exc:
+        print(
+            f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr
+        )
+        raise typer.Exit(1) from exc
+
     reader, writer = await asyncio.open_unix_connection(str(path))
     try:
-        writer.write(json.encode({"method": method, "params": params}) + b"\n")
+        writer.write(
+            json.encode({"method": method, "params": params or {}}) + b"\n"
+        )
         await writer.drain()
-        if data := await reader.readline():
+        writer.write_eof()
+        while data := await reader.readline():
             buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
             if buf is not None:
                 buf.write(data)

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -61,16 +61,12 @@ async def rpc_call(
     try:
         await ensure_daemon_running(path)
     except Exception as exc:
-        print(
-            f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr
-        )
+        print(f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr)
         raise typer.Exit(1) from exc
 
     reader, writer = await asyncio.open_unix_connection(str(path))
     try:
-        writer.write(
-            json.encode({"method": method, "params": params or {}}) + b"\n"
-        )
+        writer.write(json.encode({"method": method, "params": params or {}}) + b"\n")
         await writer.drain()
         writer.write_eof()
         while data := await reader.readline():

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+import io  # noqa: TC003
+import subprocess
+import sys
+import typing as t
+from pathlib import Path  # noqa: TC003
+
+import anyio
+from msgspec import json
+
+from weaverd.server import default_socket_path
+
+from .sockets import can_connect
+
+
+def discover_socket() -> Path:
+    """Return the daemon socket path."""
+    return default_socket_path()
+
+
+def spawn_daemon(socket_path: Path) -> subprocess.Popen[bytes]:
+    """Spawn the ``weaverd`` daemon detached from the controlling terminal."""
+    return subprocess.Popen(  # noqa: S603 -- trusted internal command
+        [sys.executable, "-m", "weaverd", "--socket-path", str(socket_path)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+async def ensure_daemon_running(socket_path: Path) -> None:
+    """Start ``weaverd`` if the socket is unavailable."""
+    if await can_connect(socket_path):
+        return
+    spawn_daemon(socket_path)
+    for _ in range(50):
+        if await can_connect(socket_path):
+            return
+        await anyio.sleep(0.1)
+    raise RuntimeError("weaverd failed to start")
+
+
+async def rpc_call(
+    method: str,
+    params: dict[str, t.Any] | None = None,
+    socket_path: Path | None = None,
+    stdout: t.TextIO | None = None,
+) -> None:
+    """Send an RPC request and stream the response to ``stdout``."""
+    path = socket_path or discover_socket()
+    stdout = t.cast("t.TextIO", sys.stdout if stdout is None else stdout)
+    await ensure_daemon_running(path)
+    reader, writer = await asyncio.open_unix_connection(str(path))
+    try:
+        writer.write(json.encode({"method": method, "params": params}) + b"\n")
+        await writer.drain()
+        if data := await reader.readline():
+            buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
+            if buf is not None:
+                buf.write(data)
+            else:
+                stdout.write(data.decode())
+            stdout.flush()
+    finally:
+        writer.close()
+        await writer.wait_closed()

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -78,8 +78,14 @@ async def test_rpc_call_autostart(
     assert json.decode(buf.getvalue().encode(), type=ProjectStatus) == ProjectStatus(
         message="ok"
     )
-    started.terminate()
-    started.join()
+    try:
+        started.terminate()
+        started.join(timeout=5.0)
+        if started.is_alive():
+            started.kill()
+    finally:
+        if started.is_alive():
+            started.kill()
 
 
 @pytest.mark.anyio

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -75,9 +75,9 @@ async def test_rpc_call_autostart(
     buf = StringIO()
     await client.rpc_call("project-status", socket_path=sock, stdout=buf)
     assert started is not None
-    assert json.decode(
-        buf.getvalue().encode(), type=ProjectStatus
-    ) == ProjectStatus(message="ok")
+    assert json.decode(buf.getvalue().encode(), type=ProjectStatus) == ProjectStatus(
+        message="ok"
+    )
     started.terminate()
     started.join()
 

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -1,0 +1,72 @@
+import asyncio
+import multiprocessing as mp
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from msgspec import json
+
+from weaver import client
+from weaver_schemas.status import ProjectStatus
+from weaverd.rpc import RPCDispatcher
+from weaverd.server import start_server
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_rpc_call_existing_daemon(tmp_path: Path) -> None:
+    dispatcher = RPCDispatcher()
+
+    @dispatcher.register("project-status")
+    async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
+        return ProjectStatus(message="ok")
+
+    sock = tmp_path / "d.sock"
+    server = await start_server(sock, dispatcher)
+    async with server:
+        buf = StringIO()
+        await client.rpc_call("project-status", socket_path=sock, stdout=buf)
+        assert json.decode(
+            buf.getvalue().encode(), type=ProjectStatus
+        ) == ProjectStatus(message="ok")
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.anyio
+async def test_rpc_call_autostart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sock = tmp_path / "auto.sock"
+
+    def spawn(path: Path) -> mp.Process:
+        def _run() -> None:
+            async def _serve() -> None:
+                server = await start_server(path, RPCDispatcher())
+                async with server:
+                    await server.serve_forever()
+
+            asyncio.run(_serve())
+
+        proc = mp.Process(target=_run)
+        proc.start()
+        return proc
+
+    started: mp.Process | None = None
+
+    def wrapped(path: Path) -> mp.Process:
+        nonlocal started
+        started = spawn(path)
+        return started
+
+    monkeypatch.setattr(client, "spawn_daemon", wrapped)
+
+    buf = StringIO()
+    await client.rpc_call("project-status", socket_path=sock, stdout=buf)
+    assert started is not None
+    started.terminate()
+    started.join()

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -46,18 +46,25 @@ async def test_rpc_call_autostart(
 
     def spawn(path: Path) -> mp.Process:
         def _run() -> None:
-            async def _serve() -> None:
-                dispatcher = RPCDispatcher()
+            # Avoid event loop conflicts in subprocesses
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
 
-                @dispatcher.register("project-status")
-                async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
-                    return ProjectStatus(message="ok")
+                async def _serve() -> None:
+                    dispatcher = RPCDispatcher()
 
-                server = await start_server(path, dispatcher)
-                async with server:
-                    await server.serve_forever()
+                    @dispatcher.register("project-status")
+                    async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
+                        return ProjectStatus(message="ok")
 
-            asyncio.run(_serve())
+                    server = await start_server(path, dispatcher)
+                    async with server:
+                        await server.serve_forever()
+
+                loop.run_until_complete(_serve())
+            finally:
+                loop.close()
 
         proc = mp.Process(target=_run)
         proc.start()
@@ -78,14 +85,13 @@ async def test_rpc_call_autostart(
     assert json.decode(buf.getvalue().encode(), type=ProjectStatus) == ProjectStatus(
         message="ok"
     )
-    try:
+    if started and started.is_alive():
         started.terminate()
-        started.join(timeout=5.0)
-        if started.is_alive():
-            started.kill()
-    finally:
-        if started.is_alive():
-            started.kill()
+        try:
+            started.join(timeout=5.0)
+        finally:
+            if started.is_alive():
+                started.kill()
 
 
 @pytest.mark.anyio

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 from msgspec import json
 
 from weaver import client
+from weaver_schemas.error import SchemaError
 from weaver_schemas.status import ProjectStatus
 from weaverd.rpc import RPCDispatcher
 from weaverd.server import start_server
@@ -46,7 +47,13 @@ async def test_rpc_call_autostart(
     def spawn(path: Path) -> mp.Process:
         def _run() -> None:
             async def _serve() -> None:
-                server = await start_server(path, RPCDispatcher())
+                dispatcher = RPCDispatcher()
+
+                @dispatcher.register("project-status")
+                async def status() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
+                    return ProjectStatus(message="ok")
+
+                server = await start_server(path, dispatcher)
                 async with server:
                     await server.serve_forever()
 
@@ -68,5 +75,22 @@ async def test_rpc_call_autostart(
     buf = StringIO()
     await client.rpc_call("project-status", socket_path=sock, stdout=buf)
     assert started is not None
+    assert json.decode(
+        buf.getvalue().encode(), type=ProjectStatus
+    ) == ProjectStatus(message="ok")
     started.terminate()
     started.join()
+
+
+@pytest.mark.anyio
+async def test_rpc_call_unknown_method(tmp_path: Path) -> None:
+    dispatcher = RPCDispatcher()
+    sock = tmp_path / "unk.sock"
+    server = await start_server(sock, dispatcher)
+    async with server:
+        buf = StringIO()
+        await client.rpc_call("nope", socket_path=sock, stdout=buf)
+        err = json.decode(buf.getvalue().encode(), type=SchemaError)
+        assert err.message == "unknown method: nope"
+    server.close()
+    await server.wait_closed()


### PR DESCRIPTION
## Summary
- add weaver client module for RPC communication
- auto-start `weaverd` when needed
- expand Typer CLI with all command stubs and project-status RPC call
- test RPC client logic and daemon auto-start
- document design decision and mark roadmap task done

## Testing
- `ruff check weaver weaverd weaver_schemas features --fix`
- `pyright`
- `markdownlint docs/roadmap.md docs/weaver-design.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cd7fe732c8322991869acac49b5f3

## Summary by Sourcery

Implement the weaver client skeleton by introducing a standalone client module for RPC communication, integrating it into the CLI with a project-status command and placeholders for future commands, enabling automatic daemon startup, and providing corresponding tests and documentation updates

New Features:
- Add a weaver client module with socket discovery, daemon auto-start, and rpc_call function
- Expand the Typer-based CLI with project-status command and stubs for all planned RPC endpoints

Enhancements:
- Automatically spawn and wait for the weaverd daemon if the socket is unavailable

Documentation:
- Update roadmap and design documents to mark the client skeleton tasks as completed and describe the daemon auto-start behavior

Tests:
- Add unit tests for rpc_call covering both existing daemon and auto-start scenarios
- Add BDD feature test for the project-status CLI command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a functional "project-status" CLI command to retrieve project status from the daemon.
  * Added multiple placeholder CLI commands for future project and code analysis features.

* **Documentation**
  * Updated roadmap to mark client skeleton tasks as completed.
  * Clarified daemon auto-start behavior and debugging options in design documentation.

* **Tests**
  * Added behavior-driven tests for the "project-status" command.
  * Added unit tests to verify client-daemon communication and auto-start functionality.

* **Chores**
  * Added `pytest-bdd` as a development dependency for behavior-driven testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->