### PR TITLE
Add msjson alias for msgspec.json

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,183 +1,282 @@
 # Weaver: Development Roadmap
 
-This document provides a detailed, task-oriented development roadmap for building the `weaver` CLI and its associated `weaverd` daemon, based on the established design specification. It is intended for the implementation team to track progress and coordinate efforts.
+This document provides a detailed, task-oriented development roadmap for
+building the `weaver` CLI and its associated `weaverd` daemon, based on the
+established design specification. It is intended for the implementation team to
+track progress and coordinate efforts.
 
-### **Phase 0: Core Scaffolding & Project Setup**
+## **Phase 0: Core Scaffolding & Project Setup**
 
-*This phase establishes the foundational architecture, project structure, and communication protocols. Completing this phase means the* `weaver` *client can successfully connect to the* `weaverd` *daemon, but no actual code intelligence functionality will be implemented yet.*
+*This phase establishes the foundational architecture, project structure, and
+communication protocols. Completing this phase means the* `weaver` *client can
+successfully connect to the* `weaverd` *daemon, but no actual code intelligence
+functionality will be implemented yet.*
 
 - [x] **Finalise Project Structure & Dependencies:**
 
-  - [x] Decide on a monorepo and use [uv](https://www.google.com/search?q=monorepo-development-with-astral-uv.md) for package and environment management.
+  - [x] Decide on a monorepo and use
+    [uv](https://www.google.com/search?q=monorepo-development-with-astral-uv.md)
+    for package and environment management.
 
-  - [x] Initialise the project with [uv](https://www.google.com/search?q=monorepo-development-with-astral-uv.md) and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for async socket communication), and `serena` (for code intelligence tools).
+  - [x] Initialise the project with
+    [uv](https://www.google.com/search?q=monorepo-development-with-astral-uv.md)
+    and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for
+    async socket communication), and `serena` (for code intelligence tools).
 
 - [x] **Define the API Contract with msgspec:**
 
-  - [x] Create a shared internal package (`weaver-schemas` or similar) containing msgspec `Struct` definitions for every JSON object specified in Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`, `ImpactReport`, etc.).
+  - [x] Create a shared internal package (`weaver-schemas` or similar)
+    containing msgspec `Struct` definitions for every JSON object specified in
+    Appendix A of the design document (`Location`, `Diagnostic`, `CodeEdit`,
+    `ImpactReport`, etc.).
 
-  - [x] Ensure all models include the `type` discriminator field (`type: Literal['diagnostic'] = 'diagnostic'`) to facilitate easy parsing of the JSONL stream on the client side. These models are the single source of truth for the API.
+  - [x] Ensure all models include the `type` discriminator field
+    (`type: Literal['diagnostic'] = 'diagnostic'`) to facilitate easy parsing
+    of the JSONL stream on the client side. These models are the single source
+    of truth for the API.
 
 - [x] **Implement the** `weaverd` **Daemon Skeleton:**
 
   - [x] Create the main `asyncio` entry point for the daemon.
 
-  - [x] Implement an RPC router that listens on a UNIX domain socket (e.g., `$XDG_RUNTIME_DIR/weaverd-$USER.sock`). Use a library like `jsonrpc-py` or build a simple dispatcher that maps method names to handler functions.
+  - [x] Implement an RPC router that listens on a UNIX domain socket (e.g.,
+    `$XDG_RUNTIME_DIR/weaverd-$USER.sock`). Use a library like `jsonrpc-py` or
+    build a simple dispatcher that maps method names to handler functions.
 
-  - [x] The dispatcher should accept JSON requests, validate them against the msgspec models, call the corresponding (stubbed) handler, and serialize the msgspec response model back to JSONL.
+  - [x] The dispatcher should accept JSON requests, validate them against the
+    msgspec models, call the corresponding (stubbed) handler, and serialize the
+    msgspec response model back to JSONL.
 
-  - [x] Implement a basic `ping` or `project-status` RPC endpoint that returns a hardcoded success response.
+  - [x] Implement a basic `ping` or `project-status` RPC endpoint that returns
+    a hardcoded success response.
 
 - [x] **Implement the** `weaver` **Client Skeleton:**
 
-  - [x] Set up the CLI using `typer`. Create a stub for each command defined in the design document.
+  - [x] Set up the CLI using `typer`. Create a stub for each command defined in
+    the design document.
 
-  - [x] Implement the socket discovery logic. The client must locate the `weaverd` socket at its well-known path.
+  - [x] Implement the socket discovery logic. The client must locate the
+    `weaverd` socket at its well-known path.
 
-  - [x] Implement the daemon auto-start logic. If the client cannot connect to the socket, it should attempt to spawn the `weaverd` process in the background (`subprocess.Popen` with appropriate flags to detach it).
+  - [x] Implement the daemon auto-start logic. If the client cannot connect to
+    the socket, it should attempt to spawn the `weaverd` process in the
+    background (`subprocess.Popen` with appropriate flags to detach it).
 
-  - [x] Implement the core RPC client function that connects to the socket, sends a msgspec-serialised request, and streams the JSONL response directly to `stdout`.
+  - [x] Implement the core RPC client function that connects to the socket,
+    sends a msgspec-serialised request, and streams the JSONL response directly
+    to `stdout`.
 
-  - [x] Implement the `weaver project-status` command to call the `ping` endpoint on the daemon. A successful run of this command validates the entire communication pipeline.
+  - [x] Implement the `weaver project-status` command to call the `ping`
+    endpoint on the daemon. A successful run of this command validates the
+    entire communication pipeline.
 
-### **Phase 1: Read-Only Verbs (Observe & Orient)**
+## **Phase 1: Read-Only Verbs (Observe & Orient)**
 
-*This phase brings the core read-only code intelligence to life. The goal is to enable the agent to inspect and understand a codebase without modifying it. This phase focuses on wrapping Serena's tool capabilities.*
+*This phase brings the core read-only code intelligence to life. The goal is to
+enable the agent to inspect and understand a codebase without modifying it.
+This phase focuses on wrapping Serena's tool capabilities.*
 
 - [ ] **Integrate Serena Tools into** `weaverd`**:**
 
-  - [ ] Implement logic within `weaverd` to initialise Serena's tool classes (e.g., from `serena.tools`) on startup, providing them with the necessary project context.
+  - [ ] Implement logic within `weaverd` to initialise Serena's tool classes
+    (e.g., from `serena.tools`) on startup, providing them with the necessary
+    project context.
 
-  - [ ] Implement the `onboard-project` command logic. This will use Serena's tools to analyse the project and establish a workspace context for subsequent commands.
+  - [ ] Implement the `onboard-project` command logic. This will use Serena's
+    tools to analyse the project and establish a workspace context for
+    subsequent commands.
 
-  - [ ] The daemon will rely on Serena's tools to manage the lifecycle of any underlying LSP connections.
+  - [ ] The daemon will rely on Serena's tools to manage the lifecycle of any
+    underlying LSP connections.
 
 - [ ] **Implement Observe Commands:**
 
-  - [ ] `project-status`: Enhance the stub to query the relevant Serena tools for the actual status of the workspace and any underlying language servers (PID, memory, readiness state).
+  - [ ] `project-status`: Enhance the stub to query the relevant Serena tools
+    for the actual status of the workspace and any underlying language servers
+    (PID, memory, readiness state).
 
-  - [ ] `list-diagnostics`: Implement the handler to call the appropriate method in Serena's toolset to get diagnostics and stream the results, converting them to the `weaver` `Diagnostic` msgspec model.
+  - [ ] `list-diagnostics`: Implement the handler to call the appropriate
+    method in Serena's toolset to get diagnostics and stream the results,
+    converting them to the `weaver` `Diagnostic` msgspec model.
 
 - [ ] **Implement Orient Commands:**
 
-  - [ ] `get-definition`: Implement the handler to call the definition-fetching method in Serena's tools.
+  - [ ] `get-definition`: Implement the handler to call the definition-fetching
+    method in Serena's tools.
 
-  - [ ] `list-references`: Implement the handler to call the reference-finding method in Serena's tools.
+  - [ ] `list-references`: Implement the handler to call the reference-finding
+    method in Serena's tools.
 
-  - [ ] `find-symbol`: Implement the handler to call the workspace symbol search method in Serena's tools.
+  - [ ] `find-symbol`: Implement the handler to call the workspace symbol
+    search method in Serena's tools.
 
-  - [ ] `summarise-symbol`: Implement the handler to call the symbol-hover/documentation method in Serena's tools and synthesise the response into the `SymbolSummary` model.
+  - [ ] `summarise-symbol`: Implement the handler to call the
+    symbol-hover/documentation method in Serena's tools and synthesise the
+    response into the `SymbolSummary` model.
 
-  - [ ] `get-call-graph` **/** `get-type-hierarchy`: Implement the handlers to use Serena's tools for call hierarchy and type hierarchy exploration. This may require recursive calls within the daemon to build out the graph to a specified depth.
+  - [ ] `get-call-graph` **/** `get-type-hierarchy`: Implement the handlers to
+    use Serena's tools for call hierarchy and type hierarchy exploration. This
+    may require recursive calls within the daemon to build out the graph to a
+    specified depth.
 
 - [ ] **Testing Strategy:**
 
-  - [ ] Create a dedicated, multi-language test repository (containing Python, Rust, and TypeScript files with known symbols, errors, and references).
+  - [ ] Create a dedicated, multi-language test repository (containing Python,
+    Rust, and TypeScript files with known symbols, errors, and references).
 
-  - [ ] Write an integration test suite that runs `weaver` commands against this repository and validates the resulting JSONL output against expected snapshots.
+  - [ ] Write an integration test suite that runs `weaver` commands against
+    this repository and validates the resulting JSONL output against expected
+    snapshots.
 
-### **Phase 2: Simulation & Analysis Verbs (Decide)**
+## **Phase 2: Simulation & Analysis Verbs (Decide)**
 
-*This phase implements the "semantic firewall" — the ability to simulate changes and analyse their impact. This is the most complex part of the read-only functionality and is critical for agent safety.*
+*This phase implements the "semantic firewall" — the ability to simulate
+changes and analyse their impact. This is the most complex part of the
+read-only functionality and is critical for agent safety.*
 
 - [ ] **Implement the Transient Edit Cache in** `weaverd`**:**
 
-  - [ ] The daemon needs an in-memory dictionary that maps file paths to their transient content (`Dict[str, str]`).
+  - [ ] The daemon needs an in-memory dictionary that maps file paths to their
+    transient content (`Dict[str, str]`).
 
-  - [ ] Before calling a Serena tool that needs to be aware of a change, the daemon must check if any files involved have a transient version. If so, it must pass the transient content to the relevant Serena tool method, which will handle the interaction with the LSP server.
+  - [ ] Before calling a Serena tool that needs to be aware of a change, the
+    daemon must check if any files involved have a transient version. If so, it
+    must pass the transient content to the relevant Serena tool method, which
+    will handle the interaction with the LSP server.
 
-  - [ ] After the request is complete, the transient overlay must be cleared to ensure the LSP server's state reverts to the on-disk state.
+  - [ ] After the request is complete, the transient overlay must be cleared to
+    ensure the LSP server's state reverts to the on-disk state.
 
 - [ ] **Implement** `with-transient-edit`**:**
 
-  - [ ] This meta-command in the client will orchestrate the process. It will first send a custom RPC call to the daemon (`_set_transient_overlay`) with the content from `stdin`.
+  - [ ] This meta-command in the client will orchestrate the process. It will
+    first send a custom RPC call to the daemon (`_set_transient_overlay`) with
+    the content from `stdin`.
 
   - [ ] It will then execute the inner command as a separate RPC call.
 
-  - [ ] Finally, it will use a `finally` block to guarantee it sends a `_clear_transient_overlay` RPC call to the daemon.
+  - [ ] Finally, it will use a `finally` block to guarantee it sends a
+    `_clear_transient_overlay` RPC call to the daemon.
 
 - [ ] **Implement** `analyse-impact`**:**
 
-  - [ ] This command will use the `with-transient-edit` flow. It will apply the proposed edit as a transient overlay and then call the Serena tool for listing diagnostics against the entire workspace, diffing the result against the baseline diagnostics to report only *new* errors.
+  - [ ] This command will use the `with-transient-edit` flow. It will apply the
+    proposed edit as a transient overlay and then call the Serena tool for
+    listing diagnostics against the entire workspace, diffing the result
+    against the baseline diagnostics to report only *new* errors.
 
 - [ ] **Implement Build/Test Wrappers:**
 
-  - [ ] Implement the `test` and `build` commands. These will execute the project-specific shell commands defined in `.weaver/project.yml`.
+  - [ ] Implement the `test` and `build` commands. These will execute the
+    project-specific shell commands defined in `.weaver/project.yml`.
 
-  - [ ] They will capture the `stdout` and `stderr` of the subprocess and parse them using regex patterns (also defined in `project.yml`) to convert the human-readable output into `weaver` `Diagnostic` objects.
+  - [ ] They will capture the `stdout` and `stderr` of the subprocess and parse
+    them using regex patterns (also defined in `project.yml`) to convert the
+    human-readable output into `weaver` `Diagnostic` objects.
 
-### **Phase 3: Mutable Verbs (Act)**
+## **Phase 3: Mutable Verbs (Act)**
 
-*This phase grants the agent the ability to safely modify the filesystem. The key principles are atomicity and decoupling planning from execution.*
+*This phase grants the agent the ability to safely modify the filesystem. The
+key principles are atomicity and decoupling planning from execution.*
 
 - [ ] **Implement** `apply-edits`**:**
 
-  - [ ] The client-side command will read a stream of `CodeEdit` objects from `stdin`.
+  - [ ] The client-side command will read a stream of `CodeEdit` objects from
+    `stdin`.
 
-  - [ ] For each unique file in the edit set, it will write the modified content to a temporary file (e.g., `main.py.weaver-tmp`).
+  - [ ] For each unique file in the edit set, it will write the modified
+    content to a temporary file (e.g., `main.py.weaver-tmp`).
 
-  - [ ] **Atomicity:** Only after *all* temporary files have been successfully written will it perform atomic `os.rename` operations to replace the original files. If any write fails, it will clean up all temporary files and exit with an error, leaving the workspace untouched.
+  - [ ] **Atomicity:** Only after *all* temporary files have been successfully
+    written will it perform atomic `os.rename` operations to replace the
+    original files. If any write fails, it will clean up all temporary files
+    and exit with an error, leaving the workspace untouched.
 
 - [ ] **Implement Plan-Generating Commands:**
 
-  - [ ] `rename-symbol`: Implement the RPC handler to call the corresponding method in Serena's `SymbolTools` to generate a rename plan. This plan must be converted into a stream of `weaver` `CodeEdit` objects.
+  - [ ] `rename-symbol`: Implement the RPC handler to call the corresponding
+    method in Serena's `SymbolTools` to generate a rename plan. This plan must
+    be converted into a stream of `weaver` `CodeEdit` objects.
 
-  - [ ] `format-code`: Implement the RPC handler to call the code formatting method in Serena's toolset and convert the result into a `CodeEdit` stream.
+  - [ ] `format-code`: Implement the RPC handler to call the code formatting
+    method in Serena's toolset and convert the result into a `CodeEdit` stream.
 
 - [ ] **Implement Workspace Management:**
 
-  - [ ] Implement the central project configuration (`~/.config/weaver/projects.yml`).
+  - [ ] Implement the central project configuration
+    (`~/.config/weaver/projects.yml`).
 
-  - [ ] `list-projects` **/** `set-active-project`: Implement the client commands and daemon handlers to read the config and switch the active workspace for Serena's tools.
+  - [ ] `list-projects` **/** `set-active-project`: Implement the client
+    commands and daemon handlers to read the config and switch the active
+    workspace for Serena's tools.
 
-  - [ ] `reload-workspace`: Implement the handler to trigger a reload or re-initialisation sequence for the active workspace via Serena's tools.
+  - [ ] `reload-workspace`: Implement the handler to trigger a reload or
+    re-initialisation sequence for the active workspace via Serena's tools.
 
-### **Phase 4: Intelligence & Persistence (Memories)**
+## **Phase 4: Intelligence & Persistence (Memories)**
 
-*This phase adds long-term memory and project-specific intelligence, allowing the agent to adapt to local conventions.*
+*This phase adds long-term memory and project-specific intelligence, allowing
+the agent to adapt to local conventions.*
 
 - [ ] **Implement** `onboard-project` **Analysis:**
 
-  - [ ] Develop the static analysis logic for the onboarding process. This will involve using Serena's tools (e.g., for symbol searching, diagnostic listing) and heuristics to identify project patterns.
+  - [ ] Develop the static analysis logic for the onboarding process. This will
+    involve using Serena's tools (e.g., for symbol searching, diagnostic
+    listing) and heuristics to identify project patterns.
 
-  - [ ] For example, to find the testing framework, it could look for imports of `pytest` or `unittest` using Serena's symbol search capabilities.
+  - [ ] For example, to find the testing framework, it could look for imports
+    of `pytest` or `unittest` using Serena's symbol search capabilities.
 
 - [ ] **Implement Memory Persistence:**
 
   - [ ] Create the `.weaver/memories/` directory structure.
 
-  - [ ] The `onboard-project` command will write its findings as a JSONL file in this directory.
+  - [ ] The `onboard-project` command will write its findings as a JSONL file
+    in this directory.
 
-  - [ ] `list-memories`: This command will simply read and stream the contents of the memory files to `stdout`.
+  - [ ] `list-memories`: This command will simply read and stream the contents
+    of the memory files to `stdout`.
 
-### **Phase 5: Polishing & Productionisation**
+## **Phase 5: Polishing & Productionisation**
 
 *This final phase focuses on robustness, usability, and distribution.*
 
 - [ ] **Implement Resource Management in** `weaverd`**:**
 
-  - [ ] Add logic to monitor the memory and CPU usage of the daemon and any child processes spawned by Serena's tools.
+  - [ ] Add logic to monitor the memory and CPU usage of the daemon and any
+    child processes spawned by Serena's tools.
 
-  - [ ] If the limits defined by `WEAVER_MAX_RAM_MB` or `WEAVER_MAX_CPUS` are exceeded, the daemon should gracefully reject new requests with a structured `Error` object.
+  - [ ] If the limits defined by `WEAVER_MAX_RAM_MB` or `WEAVER_MAX_CPUS` are
+    exceeded, the daemon should gracefully reject new requests with a
+    structured `Error` object.
 
 - [ ] **Implement Job Cancellation:**
 
-  - [ ] The `asyncio` tasks in the daemon that handle long-running requests should be cancellable.
+  - [ ] The `asyncio` tasks in the daemon that handle long-running requests
+    should be cancellable.
 
-  - [ ] The client should handle `SIGINT` (Ctrl+C) and send a custom `_cancel_request` RPC call to the daemon.
+  - [ ] The client should handle `SIGINT` (Ctrl+C) and send a custom
+    `_cancel_request` RPC call to the daemon.
 
 - [ ] **Implement Schema Generation:**
 
-  - [ ] Add the `weaver --json-schema` command. This will iterate through all msgspec models and call `msgspec.json.schema(Model)` to generate a complete JSON Schema for the entire API, emitting it via `json.dumps`.
+  - [ ] Add the `weaver --json-schema` command. This will iterate through all
+    msgspec models and call `msgspec.json.schema(Model)` to generate a complete
+    JSON Schema for the entire API, emitting it via `json.dumps`.
 
 - [ ] **Package for Distribution:**
 
-  - [ ] Set up a build process using **PyOxidiser** to package the `weaver` client into a single, static executable for easy distribution and minimal startup overhead.
+  - [ ] Set up a build process using **PyOxidiser** to package the `weaver`
+    client into a single, static executable for easy distribution and minimal
+    startup overhead.
 
-  - [ ] Create installation scripts or packages for `weaverd` to be run as a systemd/launchd service.
+  - [ ] Create installation scripts or packages for `weaverd` to be run as a
+    systemd/launchd service.
 
 - [ ] **Documentation:**
 
-  - [ ] Write comprehensive documentation for each command, including examples of its JSONL output.
+  - [ ] Write comprehensive documentation for each command, including examples
+    of its JSONL output.
 
-  - [ ] Document the configuration file formats (`projects.yml` and `.weaver/project.yml`).
+  - [ ] Document the configuration file formats (`projects.yml` and
+    `.weaver/project.yml`).

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -144,11 +144,11 @@ objects conforming to the schemas defined in Appendix A.
 
 ### 2.1 Observe
 
-| Command          | Synopsis                                                                      |
-| ---------------- | ----------------------------------------------------------------------------- |
-| project-status   | Health of daemon & language servers; RAM/CPU usage; protocol version.         |
+| Command          | Synopsis                                                                        |
+| ---------------- | ------------------------------------------------------------------------------- |
+| project-status   | Health of daemon & language servers; RAM/CPU usage; protocol version.           |
 | list-diagnostics | `[--severity S] [<files…>]` Stream Diagnostics for whole workspace or subset.   |
-| onboard-project  | First-run analysis, populates memories & returns OnboardingReport.            |
+| onboard-project  | First-run analysis, populates memories & returns OnboardingReport.              |
 
 ### 2.2 Orient
 
@@ -374,4 +374,81 @@ class Diagnostic(Struct):
 # ... and so on for Symbol, Reference, CodeEdit, ImpactReport,
 # TestResult, OnboardingReport, Error, etc.
 
+```
+
+```mermaid
+classDiagram
+    class Position {
+        +int line
+        +int character
+    }
+    class Range {
+        +Position start
+        +Position end
+    }
+    class Location {
+        +str file
+        +Range range
+    }
+    class Diagnostic {
+        +Location location
+        +str message
+        +str severity
+        +str type
+    }
+    class CodeEdit {
+        +str file
+        +Range range
+        +str replacement
+        +str type
+    }
+    class Symbol {
+        +str name
+        +str kind
+        +str type
+    }
+    class Reference {
+        +Location location
+        +str type
+    }
+    class ImpactReport {
+        +list~Diagnostic~ diagnostics
+        +str type
+    }
+    class TestResult {
+        +str name
+        +str outcome
+        +str type
+    }
+    class OnboardingReport {
+        +str details
+        +str type
+    }
+    class SchemaError {
+        +str message
+    }
+    class ProjectStatus {
+        +str message
+    }
+
+    %% All classes now inherit from msgspec.Struct
+    Position --|> msgspec.Struct
+    Range --|> msgspec.Struct
+    Location --|> msgspec.Struct
+    Diagnostic --|> msgspec.Struct
+    CodeEdit --|> msgspec.Struct
+    Symbol --|> msgspec.Struct
+    Reference --|> msgspec.Struct
+    ImpactReport --|> msgspec.Struct
+    TestResult --|> msgspec.Struct
+    OnboardingReport --|> msgspec.Struct
+    SchemaError --|> msgspec.Struct
+    ProjectStatus --|> msgspec.Struct
+
+    %% Relationships
+    Range --> Position : start/end
+    Location --> Range : range
+    Diagnostic --> Location : location
+    Reference --> Location : location
+    ImpactReport --> Diagnostic : diagnostics
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ banned-from = [
     "dataclasses",
     "enum",
     "unittest.mock",
+    "msgspec",
 ]
 
 [tool.ruff.lint.flake8-import-conventions.aliases]
@@ -85,6 +86,7 @@ scipy = "sp"
 "collections.abc" = "cabc"
 datetime = "dt"
 "unittest.mock" = "mock"
+"msgspec.json" = "msjson"
 
 [tool.pytest.ini_options]
 # Ensure asyncio fixtures create a new event loop for each test

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -9,8 +9,8 @@ import typing as t
 from pathlib import Path  # noqa: TC003
 
 import anyio
+import msgspec.json as msjson
 import typer
-from msgspec import json
 
 from weaverd.server import default_socket_path
 
@@ -66,7 +66,7 @@ async def rpc_call(
 
     reader, writer = await asyncio.open_unix_connection(str(path))
     try:
-        writer.write(json.encode({"method": method, "params": params or {}}) + b"\n")
+        writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
         await writer.drain()
         writer.write_eof()
         while data := await reader.readline():

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -3,8 +3,8 @@ import multiprocessing as mp
 from io import StringIO
 from pathlib import Path
 
+import msgspec.json as msjson
 import pytest
-from msgspec import json
 
 from weaver import client
 from weaver_schemas.error import SchemaError
@@ -31,7 +31,7 @@ async def test_rpc_call_existing_daemon(tmp_path: Path) -> None:
     async with server:
         buf = StringIO()
         await client.rpc_call("project-status", socket_path=sock, stdout=buf)
-        assert json.decode(
+        assert msjson.decode(
             buf.getvalue().encode(), type=ProjectStatus
         ) == ProjectStatus(message="ok")
     server.close()
@@ -82,7 +82,7 @@ async def test_rpc_call_autostart(
     buf = StringIO()
     await client.rpc_call("project-status", socket_path=sock, stdout=buf)
     assert started is not None
-    assert json.decode(buf.getvalue().encode(), type=ProjectStatus) == ProjectStatus(
+    assert msjson.decode(buf.getvalue().encode(), type=ProjectStatus) == ProjectStatus(
         message="ok"
     )
     if started and started.is_alive():
@@ -102,7 +102,7 @@ async def test_rpc_call_unknown_method(tmp_path: Path) -> None:
     async with server:
         buf = StringIO()
         await client.rpc_call("nope", socket_path=sock, stdout=buf)
-        err = json.decode(buf.getvalue().encode(), type=SchemaError)
+        err = msjson.decode(buf.getvalue().encode(), type=SchemaError)
         assert err.message == "unknown method: nope"
     server.close()
     await server.wait_closed()

--- a/weaver/unittests/test_schemas.py
+++ b/weaver/unittests/test_schemas.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import typing as t
 
+import msgspec.json as msjson
 import pytest
-from msgspec import json
 
 from weaver_schemas import (
     CodeEdit,
@@ -25,8 +25,8 @@ def make_diagnostic() -> Diagnostic:
 
 def test_diagnostic_roundtrip() -> None:
     diag = make_diagnostic()
-    data = json.encode(diag)
-    assert json.decode(data, type=Diagnostic) == diag
+    data = msjson.encode(diag)
+    assert msjson.decode(data, type=Diagnostic) == diag
 
 
 def test_codeedit_roundtrip() -> None:
@@ -35,32 +35,32 @@ def test_codeedit_roundtrip() -> None:
         range=Range(start=Position(1, 0), end=Position(1, 1)),
         new_text="bar",
     )
-    data = json.encode(edit)
-    assert json.decode(data, type=CodeEdit) == edit
+    data = msjson.encode(edit)
+    assert msjson.decode(data, type=CodeEdit) == edit
 
 
 def test_impact_report_roundtrip() -> None:
     report = ImpactReport(diagnostics=[make_diagnostic()])
-    data = json.encode(report)
-    assert json.decode(data, type=ImpactReport) == report
+    data = msjson.encode(report)
+    assert msjson.decode(data, type=ImpactReport) == report
 
 
 def test_test_result_roundtrip() -> None:
     result = SchemaTestResult(name="pytest", status="passed", output="ok")
-    data = json.encode(result)
-    assert json.decode(data, type=SchemaTestResult) == result
+    data = msjson.encode(result)
+    assert msjson.decode(data, type=SchemaTestResult) == result
 
 
 def test_impact_report_empty_list() -> None:
     report = ImpactReport(diagnostics=[])
-    data = json.encode(report)
-    assert json.decode(data, type=ImpactReport) == report
+    data = msjson.encode(report)
+    assert msjson.decode(data, type=ImpactReport) == report
 
 
 def test_test_result_none_output() -> None:
     result = SchemaTestResult(name="pytest", status="failed", output=None)
-    data = json.encode(result)
-    assert json.decode(data, type=SchemaTestResult) == result
+    data = msjson.encode(result)
+    assert msjson.decode(data, type=SchemaTestResult) == result
 
 
 @pytest.mark.parametrize("severity", ["Error", "Warning", "Info", "Hint"])
@@ -76,8 +76,8 @@ def test_diagnostic_severity_roundtrip(
         code=None,
         message="msg",
     )
-    data = json.encode(diag)
-    assert json.decode(data, type=Diagnostic) == diag
+    data = msjson.encode(diag)
+    assert msjson.decode(data, type=Diagnostic) == diag
 
 
 @pytest.mark.parametrize("status", ["passed", "failed", "error", "skipped"])
@@ -85,5 +85,5 @@ def test_test_result_status_roundtrip(
     status: t.Literal["passed", "failed", "error", "skipped"],
 ) -> None:
     result = SchemaTestResult(name="pytest", status=status)
-    data = json.encode(result)
-    assert json.decode(data, type=SchemaTestResult) == result
+    data = msjson.encode(result)
+    assert msjson.decode(data, type=SchemaTestResult) == result

--- a/weaver/unittests/test_schemas.py
+++ b/weaver/unittests/test_schemas.py
@@ -40,7 +40,7 @@ def test_codeedit_roundtrip() -> None:
 
 
 def test_impact_report_roundtrip() -> None:
-    report = ImpactReport(diagnostics=[make_diagnostic()])
+    report = ImpactReport(diagnostics=(make_diagnostic(),))
     data = msjson.encode(report)
     assert msjson.decode(data, type=ImpactReport) == report
 
@@ -52,7 +52,7 @@ def test_test_result_roundtrip() -> None:
 
 
 def test_impact_report_empty_list() -> None:
-    report = ImpactReport(diagnostics=[])
+    report = ImpactReport(diagnostics=())
     data = msjson.encode(report)
     assert msjson.decode(data, type=ImpactReport) == report
 

--- a/weaver_schemas/diagnostics.py
+++ b/weaver_schemas/diagnostics.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct
+import msgspec
 
 from .primitives import Location  # noqa: TC001
 
 
-class Diagnostic(Struct):
+class Diagnostic(msgspec.Struct):
     """A compiler or linter message."""
 
     location: Location

--- a/weaver_schemas/edits.py
+++ b/weaver_schemas/edits.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct
+import msgspec
 
 from .primitives import Range  # noqa: TC001
 
 
-class CodeEdit(Struct):
+class CodeEdit(msgspec.Struct):
     """A text replacement within a file."""
 
     file: str

--- a/weaver_schemas/error.py
+++ b/weaver_schemas/error.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct
+import msgspec
 
 
-class SchemaError(Struct):
+class SchemaError(msgspec.Struct):
     """A structured error message."""
 
     message: str

--- a/weaver_schemas/primitives.py
+++ b/weaver_schemas/primitives.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-from msgspec import Struct
+import msgspec
 
 
-class Position(Struct):
+class Position(msgspec.Struct):
     """A point in a text file."""
 
     line: int
     character: int
 
 
-class Range(Struct):
+class Range(msgspec.Struct):
     """A span of text between two positions."""
 
     start: Position
     end: Position
 
 
-class Location(Struct):
+class Location(msgspec.Struct):
     """A range of text within a file."""
 
     file: str

--- a/weaver_schemas/references.py
+++ b/weaver_schemas/references.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct
+import msgspec
 
 from .primitives import Location  # noqa: TC001
 
 
-class Symbol(Struct):
+class Symbol(msgspec.Struct):
     """A named code symbol."""
 
     name: str
@@ -16,7 +16,7 @@ class Symbol(Struct):
     type: t.Literal["symbol"] = "symbol"
 
 
-class Reference(Struct):
+class Reference(msgspec.Struct):
     """A reference to a symbol."""
 
     location: Location

--- a/weaver_schemas/reports.py
+++ b/weaver_schemas/reports.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct
+import msgspec
 
 from .diagnostics import Diagnostic  # noqa: TC001
 
 
-class ImpactReport(Struct):
+class ImpactReport(msgspec.Struct):
     """Result of analysing a proposed change."""
 
     diagnostics: list[Diagnostic]
     type: t.Literal["impact"] = "impact"
 
 
-class TestResult(Struct):
+class TestResult(msgspec.Struct):
     """Outcome of a project test run."""
 
     name: str
@@ -23,7 +23,7 @@ class TestResult(Struct):
     type: t.Literal["test-result"] = "test-result"
 
 
-class OnboardingReport(Struct):
+class OnboardingReport(msgspec.Struct):
     """Information gathered during project onboarding."""
 
     details: str

--- a/weaver_schemas/reports.py
+++ b/weaver_schemas/reports.py
@@ -7,10 +7,10 @@ import msgspec
 from .diagnostics import Diagnostic  # noqa: TC001
 
 
-class ImpactReport(msgspec.Struct):
+class ImpactReport(msgspec.Struct, frozen=True):
     """Result of analysing a proposed change."""
 
-    diagnostics: list[Diagnostic]
+    diagnostics: tuple[Diagnostic, ...]
     type: t.Literal["impact"] = "impact"
 
 

--- a/weaver_schemas/status.py
+++ b/weaver_schemas/status.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct
+import msgspec
 
 
-class ProjectStatus(Struct, frozen=True):
+class ProjectStatus(msgspec.Struct, frozen=True):
     """Basic daemon health indicator."""
 
     message: str

--- a/weaverd/rpc.py
+++ b/weaverd/rpc.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import typing as t
 
-from msgspec import Struct, json
+import msgspec
+import msgspec.json as msjson
 
 from weaver_schemas.error import SchemaError
 
 Handler = t.Callable[..., t.Awaitable[t.Any]]
 
 
-class RPCRequest(Struct):
+class RPCRequest(msgspec.Struct):
     """JSON-RPC style request."""
 
     method: str
@@ -31,17 +32,19 @@ class RPCDispatcher:
 
     async def handle(self, data: bytes) -> bytes:
         try:
-            request = json.decode(data, type=RPCRequest)
+            request = msjson.decode(data, type=RPCRequest)
         except Exception as exc:  # noqa: BLE001 - fallback for malformed input
-            return json.encode(SchemaError(message=f"invalid request: {exc}"))
+            return msjson.encode(SchemaError(message=f"invalid request: {exc}"))
 
         handler = self._handlers.get(request.method)
         if handler is None:
-            return json.encode(SchemaError(message=f"unknown method: {request.method}"))
+            return msjson.encode(
+                SchemaError(message=f"unknown method: {request.method}")
+            )
 
         try:
             result = await handler(**(request.params or {}))
         except Exception as exc:  # noqa: BLE001 - ensure structured errors
-            return json.encode(SchemaError(message=str(exc)))
+            return msjson.encode(SchemaError(message=str(exc)))
 
-        return json.encode(result)
+        return msjson.encode(result)

--- a/weaverd/rpc.py
+++ b/weaverd/rpc.py
@@ -33,7 +33,7 @@ class RPCDispatcher:
     async def handle(self, data: bytes) -> bytes:
         try:
             request = msjson.decode(data, type=RPCRequest)
-        except Exception as exc:  # noqa: BLE001 - fallback for malformed input
+        except msgspec.DecodeError as exc:
             return msjson.encode(SchemaError(message=f"invalid request: {exc}"))
 
         handler = self._handlers.get(request.method)

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from msgspec import json
+import msgspec.json as msjson
 
 from weaver_schemas.error import SchemaError
 from weaver_schemas.status import ProjectStatus
@@ -30,7 +30,7 @@ async def handle_client(
             try:
                 response = await dispatcher.handle(data.rstrip())
             except Exception as exc:  # noqa: BLE001 pragma: no cover - fallback
-                response = json.encode(SchemaError(message=str(exc)))
+                response = msjson.encode(SchemaError(message=str(exc)))
             writer.write(response + b"\n")
             await writer.drain()
     finally:

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import msgspec.json as msjson
 import pytest
-from msgspec import json
 
 from weaver_schemas.error import SchemaError
 from weaver_schemas.status import ProjectStatus
@@ -21,9 +21,9 @@ async def test_dispatcher_handles_registered_method() -> None:
     async def handler() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
         return ProjectStatus(message="ok")
 
-    request = json.encode({"method": "project-status"})
+    request = msjson.encode({"method": "project-status"})
     response = await dispatcher.handle(request)
-    assert json.decode(response, type=ProjectStatus) == ProjectStatus(message="ok")
+    assert msjson.decode(response, type=ProjectStatus) == ProjectStatus(message="ok")
 
 
 @pytest.mark.anyio
@@ -34,18 +34,18 @@ async def test_dispatcher_passes_parameters() -> None:
     async def echo(value: int) -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
         return ProjectStatus(message=str(value))
 
-    request = json.encode({"method": "echo", "params": {"value": 42}})
+    request = msjson.encode({"method": "echo", "params": {"value": 42}})
     response = await dispatcher.handle(request)
-    assert json.decode(response, type=ProjectStatus) == ProjectStatus(message="42")
+    assert msjson.decode(response, type=ProjectStatus) == ProjectStatus(message="42")
 
 
 @pytest.mark.anyio
 async def test_dispatcher_returns_error_on_unknown_method() -> None:
     dispatcher = RPCDispatcher()
 
-    request = json.encode({"method": "missing"})
+    request = msjson.encode({"method": "missing"})
     response = await dispatcher.handle(request)
-    assert json.decode(response, type=SchemaError) == SchemaError(
+    assert msjson.decode(response, type=SchemaError) == SchemaError(
         message="unknown method: missing"
     )
 
@@ -55,5 +55,5 @@ async def test_dispatcher_returns_error_on_bad_json() -> None:
     dispatcher = RPCDispatcher()
 
     response = await dispatcher.handle(b"not-json")
-    err = json.decode(response, type=SchemaError)
+    err = msjson.decode(response, type=SchemaError)
     assert err.type == "error" and "invalid request" in err.message

--- a/weaverd/unittests/test_server.py
+++ b/weaverd/unittests/test_server.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import typing as t
 
+import msgspec.json as msjson
 import pytest
-from msgspec import json
 
 from weaver_schemas.status import ProjectStatus
 from weaverd.rpc import RPCDispatcher
@@ -32,10 +32,10 @@ async def test_server_echoes_status(tmp_path: Path) -> None:
     server = await start_server(sock, dispatcher)
     async with server:
         reader, writer = await asyncio.open_unix_connection(str(sock))
-        writer.write(json.encode({"method": "project-status"}) + b"\n")
+        writer.write(msjson.encode({"method": "project-status"}) + b"\n")
         await writer.drain()
         data = await reader.readline()
-        assert json.decode(data.rstrip(), type=ProjectStatus) == ProjectStatus(
+        assert msjson.decode(data.rstrip(), type=ProjectStatus) == ProjectStatus(
             message="ok"
         )
         writer.close()
@@ -58,11 +58,11 @@ async def test_server_handles_multiple_requests(tmp_path: Path) -> None:
         reader, writer = await asyncio.open_unix_connection(str(sock))
         for i in (1, 2):
             writer.write(
-                json.encode({"method": "echo", "params": {"value": i}}) + b"\n"
+                msjson.encode({"method": "echo", "params": {"value": i}}) + b"\n"
             )
             await writer.drain()
             data = await reader.readline()
-            assert json.decode(data.rstrip(), type=ProjectStatus) == ProjectStatus(
+            assert msjson.decode(data.rstrip(), type=ProjectStatus) == ProjectStatus(
                 message=str(i)
             )
         writer.close()


### PR DESCRIPTION
## Summary
- ban direct imports from msgspec
- alias `msgspec.json` to `msjson`
- update msgspec imports across packages
- fix Markdown heading levels

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6881441cea5c8322be25c25aecebc2c1

## Summary by Sourcery

Introduce and enforce a msjson alias for msgspec.json, migrate all JSON encoding/decoding to use msjson, ban direct msgspec imports, update import conventions in the build config, and adjust Markdown heading levels in documentation.

New Features:
- Add msjson alias for msgspec.json in import conventions to prevent direct msgspec imports

Enhancements:
- Migrate all code to import JSON encode/decode functionality via msjson and switch Struct definitions to msgspec.Struct
- Update pyproject.toml to ban direct msgspec imports and register the msgspec.json to msjson alias

Documentation:
- Fix Markdown heading levels in docs/roadmap.md for consistency

Tests:
- Refactor unit tests to use msjson.encode/decode instead of json.encode/decode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved formatting and readability of documentation without changing content.
  * Standardized import statements and usage of JSON encoding/decoding throughout the codebase.
  * Updated class inheritance syntax for consistency.
  * Enhanced documentation with a detailed visual class diagram illustrating data schemas.
  * Made certain data structures immutable to improve reliability.

* **Chores**
  * Updated linter configuration to enforce new import conventions.

* **Tests**
  * Updated test suites to use the new import style for JSON serialization and deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->