### PR TITLE
Enforce typ alias for typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ scipy = "sp"
 "collections.abc" = "cabc"
 datetime = "dt"
 "unittest.mock" = "mock"
+typing = "typ"
 
 [tool.pytest.ini_options]
 # Ensure asyncio fixtures create a new event loop for each test

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 from pathlib import Path  # noqa: TC003 -- Typer evaluates this at runtime
 
 import anyio
@@ -35,7 +35,7 @@ def _todo(name: str) -> None:
     raise typer.Exit(1)
 
 
-def _make_stub(name: str) -> t.Callable[[], None]:
+def _make_stub(name: str) -> typ.Callable[[], None]:
     def command() -> None:  # pragma: no cover - stub
         _todo(name)
 

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -5,7 +5,7 @@ import io  # noqa: TC003
 import os
 import subprocess
 import sys
-import typing as t
+import typing as typ
 from pathlib import Path  # noqa: TC003
 
 import anyio
@@ -51,13 +51,13 @@ async def ensure_daemon_running(socket_path: Path) -> None:
 
 async def rpc_call(
     method: str,
-    params: dict[str, t.Any] | None = None,
+    params: dict[str, typ.Any] | None = None,
     socket_path: Path | None = None,
-    stdout: t.TextIO | None = None,
+    stdout: typ.TextIO | None = None,
 ) -> None:
     """Send an RPC request and stream the response to ``stdout``."""
     path = socket_path or discover_socket()
-    stdout = t.cast("t.TextIO", sys.stdout if stdout is None else stdout)
+    stdout = typ.cast("typ.TextIO", sys.stdout if stdout is None else stdout)
     try:
         await ensure_daemon_running(path)
     except Exception as exc:

--- a/weaver/unittests/test_schemas.py
+++ b/weaver/unittests/test_schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 import pytest
 from msgspec import json
@@ -65,7 +65,7 @@ def test_test_result_none_output() -> None:
 
 @pytest.mark.parametrize("severity", ["Error", "Warning", "Info", "Hint"])
 def test_diagnostic_severity_roundtrip(
-    severity: t.Literal["Error", "Warning", "Info", "Hint"],
+    severity: typ.Literal["Error", "Warning", "Info", "Hint"],
 ) -> None:
     diag = Diagnostic(
         location=Location(
@@ -82,7 +82,7 @@ def test_diagnostic_severity_roundtrip(
 
 @pytest.mark.parametrize("status", ["passed", "failed", "error", "skipped"])
 def test_test_result_status_roundtrip(
-    status: t.Literal["passed", "failed", "error", "skipped"],
+    status: typ.Literal["passed", "failed", "error", "skipped"],
 ) -> None:
     result = SchemaTestResult(name="pytest", status=status)
     data = json.encode(result)

--- a/weaver_schemas/diagnostics.py
+++ b/weaver_schemas/diagnostics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct
 
@@ -11,10 +11,10 @@ class Diagnostic(Struct):
     """A compiler or linter message."""
 
     location: Location
-    severity: t.Literal["Error", "Warning", "Info", "Hint"]
+    severity: typ.Literal["Error", "Warning", "Info", "Hint"]
     code: str | None
     message: str
-    type: t.Literal["diagnostic"] = "diagnostic"
+    type: typ.Literal["diagnostic"] = "diagnostic"
 
 
 __all__ = ["Diagnostic"]

--- a/weaver_schemas/edits.py
+++ b/weaver_schemas/edits.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct
 
@@ -13,7 +13,7 @@ class CodeEdit(Struct):
     file: str
     range: Range
     new_text: str
-    type: t.Literal["edit"] = "edit"
+    type: typ.Literal["edit"] = "edit"
 
 
 __all__ = ["CodeEdit"]

--- a/weaver_schemas/error.py
+++ b/weaver_schemas/error.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct
 
@@ -9,7 +9,7 @@ class SchemaError(Struct):
     """A structured error message."""
 
     message: str
-    type: t.Literal["error"] = "error"
+    type: typ.Literal["error"] = "error"
 
 
 __all__ = ["SchemaError"]

--- a/weaver_schemas/references.py
+++ b/weaver_schemas/references.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct
 
@@ -13,14 +13,14 @@ class Symbol(Struct):
     name: str
     kind: str
     location: Location
-    type: t.Literal["symbol"] = "symbol"
+    type: typ.Literal["symbol"] = "symbol"
 
 
 class Reference(Struct):
     """A reference to a symbol."""
 
     location: Location
-    type: t.Literal["reference"] = "reference"
+    type: typ.Literal["reference"] = "reference"
 
 
 __all__ = ["Reference", "Symbol"]

--- a/weaver_schemas/reports.py
+++ b/weaver_schemas/reports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct
 
@@ -11,23 +11,23 @@ class ImpactReport(Struct):
     """Result of analysing a proposed change."""
 
     diagnostics: list[Diagnostic]
-    type: t.Literal["impact"] = "impact"
+    type: typ.Literal["impact"] = "impact"
 
 
 class TestResult(Struct):
     """Outcome of a project test run."""
 
     name: str
-    status: t.Literal["passed", "failed", "error", "skipped"]
+    status: typ.Literal["passed", "failed", "error", "skipped"]
     output: str | None = None
-    type: t.Literal["test-result"] = "test-result"
+    type: typ.Literal["test-result"] = "test-result"
 
 
 class OnboardingReport(Struct):
     """Information gathered during project onboarding."""
 
     details: str
-    type: t.Literal["onboarding"] = "onboarding"
+    type: typ.Literal["onboarding"] = "onboarding"
 
 
 __all__ = ["ImpactReport", "OnboardingReport", "TestResult"]

--- a/weaver_schemas/status.py
+++ b/weaver_schemas/status.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct
 
@@ -9,7 +9,7 @@ class ProjectStatus(Struct, frozen=True):
     """Basic daemon health indicator."""
 
     message: str
-    type: t.Literal["project-status"] = "project-status"
+    type: typ.Literal["project-status"] = "project-status"
 
 
 __all__ = ["ProjectStatus"]

--- a/weaverd/rpc.py
+++ b/weaverd/rpc.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import typing as t
+import typing as typ
 
 from msgspec import Struct, json
 
 from weaver_schemas.error import SchemaError
 
-Handler = t.Callable[..., t.Awaitable[t.Any]]
+Handler = typ.Callable[..., typ.Awaitable[typ.Any]]
 
 
 class RPCRequest(Struct):
     """JSON-RPC style request."""
 
     method: str
-    params: dict[str, t.Any] | None = None
+    params: dict[str, typ.Any] | None = None
 
 
 class RPCDispatcher:
@@ -22,7 +22,7 @@ class RPCDispatcher:
     def __init__(self) -> None:
         self._handlers: dict[str, Handler] = {}
 
-    def register(self, name: str) -> t.Callable[[Handler], Handler]:
+    def register(self, name: str) -> typ.Callable[[Handler], Handler]:
         def decorator(func: Handler) -> Handler:
             self._handlers[name] = func
             return func

--- a/weaverd/unittests/test_server.py
+++ b/weaverd/unittests/test_server.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
+import typing as typ
 
 import pytest
 from msgspec import json
@@ -16,7 +16,7 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-if t.TYPE_CHECKING:
+if typ.TYPE_CHECKING:
     from pathlib import Path
 
 


### PR DESCRIPTION
## Summary
- add alias `typ` for the `typing` module
- rename typing imports across the codebase

## Testing
- `ruff format --check`
- `ruff check`
- `ty check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688148cc583c83228c7a19188a825b5a

## Summary by Sourcery

Enforce the use of a unified alias for the typing module by replacing all imports of typing as 't' with 'typ' and updating references accordingly.

Enhancements:
- Replace all imports of typing as 't' with 'typ' across source and schema files
- Update type hints and Literal usages to reference typ instead of t
- Apply the typ alias in CLI stubs, RPC handlers, and client functions

Build:
- Add an import-alias mapping for typing to 'typ' in pyproject.toml

Tests:
- Update unit tests to use typ.Literal and other typ-based annotations