### PR TITLE
Add RPC request schema diagram

### DIFF
--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -431,6 +431,12 @@ classDiagram
         +str message
     }
 
+    class RPCRequest {
+        +str method
+        +object|array|null params
+        +str|int|null id
+    }
+
     %% All classes now inherit from msgspec.Struct
     Position --|> msgspec.Struct
     Range --|> msgspec.Struct
@@ -444,6 +450,7 @@ classDiagram
     OnboardingReport --|> msgspec.Struct
     SchemaError --|> msgspec.Struct
     ProjectStatus --|> msgspec.Struct
+    RPCRequest --|> msgspec.Struct
 
     %% Relationships
     Range --> Position : start/end
@@ -451,19 +458,4 @@ classDiagram
     Diagnostic --> Location : location
     Reference --> Location : location
     ImpactReport --> Diagnostic : diagnostics
-```
-
-```mermaid
-classDiagram
-    class RPCRequest {
-        +str method
-        +dict params
-        +str id
-    }
-    RPCRequest --|> msgspec.Struct
-
-    class SchemaError {
-        +str message
-    }
-    SchemaError --|> msgspec.Struct
 ```

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -459,3 +459,18 @@ classDiagram
     Reference --> Location : location
     ImpactReport --> Diagnostic : diagnostics
 ```
+
+```mermaid
+classDiagram
+    class RPCRequest {
+        +str method
+        +dict params
+        +str id
+    }
+    RPCRequest --|> msgspec.Struct
+
+    class SchemaError {
+        +str message
+    }
+    SchemaError --|> msgspec.Struct
+```

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -452,3 +452,18 @@ classDiagram
     Reference --> Location : location
     ImpactReport --> Diagnostic : diagnostics
 ```
+
+```mermaid
+classDiagram
+    class RPCRequest {
+        +str method
+        +dict params
+        +str id
+    }
+    RPCRequest --|> msgspec.Struct
+
+    class SchemaError {
+        +str message
+    }
+    SchemaError --|> msgspec.Struct
+```

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -459,18 +459,3 @@ classDiagram
     Reference --> Location : location
     ImpactReport --> Diagnostic : diagnostics
 ```
-
-```mermaid
-classDiagram
-    class RPCRequest {
-        +str method
-        +dict params
-        +str id
-    }
-    RPCRequest --|> msgspec.Struct
-
-    class SchemaError {
-        +str message
-    }
-    SchemaError --|> msgspec.Struct
-```


### PR DESCRIPTION
## Summary
- add mermaid diagram for `RPCRequest` and `SchemaError`

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound copying files)*

------
https://chatgpt.com/codex/tasks/task_e_688153285fb083228715239c17ec4006

## Summary by Sourcery

Add RPCRequest schema diagram to weaver-design documentation

Documentation:
- Include RPCRequest class with fields method, params, and id in the existing class diagram
- Add a separate Mermaid diagram snippet illustrating RPCRequest and SchemaError structures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Mermaid class diagram illustrating the structure of the `RPCRequest` data type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->