### PR TITLE
Make schemas immutable and tighten imports

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ building the `weaver` CLI and its associated `weaverd` daemon, based on the
 established design specification. It is intended for the implementation team to
 track progress and coordinate efforts.
 
-## **Phase 0: Core Scaffolding & Project Setup**
+## Phase 0: Core Scaffolding & Project Setup
 
 *This phase establishes the foundational architecture, project structure, and
 communication protocols. Completing this phase means the* `weaver` *client can
@@ -15,13 +15,13 @@ functionality will be implemented yet.*
 - [x] **Finalise Project Structure & Dependencies:**
 
   - [x] Decide on a monorepo and use
-    [uv](https://www.google.com/search?q=monorepo-development-with-astral-uv.md)
-    for package and environment management.
+    [UV](https://github.com/astral-sh/uv) for package and environment
+    management.
 
   - [x] Initialise the project with
-    [uv](https://www.google.com/search?q=monorepo-development-with-astral-uv.md)
-    and add core dependencies: `msgspec`, `typer` (for the CLI), `anyio` (for
-    async socket communication), and `serena` (for code intelligence tools).
+    [UV](https://github.com/astral-sh/uv) and add core dependencies: `msgspec`,
+    `typer` (for the CLI), `anyio` (for async socket communication), and
+    `serena` (for code intelligence tools).
 
 - [x] **Define the API Contract with msgspec:**
 
@@ -70,7 +70,7 @@ functionality will be implemented yet.*
     endpoint on the daemon. A successful run of this command validates the
     entire communication pipeline.
 
-## **Phase 1: Read-Only Verbs (Observe & Orient)**
+## Phase 1: Read-Only Verbs (Observe & Orient)
 
 *This phase brings the core read-only code intelligence to life. The goal is to
 enable the agent to inspect and understand a codebase without modifying it.
@@ -128,7 +128,7 @@ This phase focuses on wrapping Serena's tool capabilities.*
     this repository and validates the resulting JSONL output against expected
     snapshots.
 
-## **Phase 2: Simulation & Analysis Verbs (Decide)**
+## Phase 2: Simulation & Analysis Verbs (Decide)
 
 *This phase implements the "semantic firewall" — the ability to simulate
 changes and analyse their impact. This is the most complex part of the
@@ -174,7 +174,7 @@ read-only functionality and is critical for agent safety.*
     them using regex patterns (also defined in `project.yml`) to convert the
     human-readable output into `weaver` `Diagnostic` objects.
 
-## **Phase 3: Mutable Verbs (Act)**
+## Phase 3: Mutable Verbs (Act)
 
 *This phase grants the agent the ability to safely modify the filesystem. The
 key principles are atomicity and decoupling planning from execution.*
@@ -213,7 +213,7 @@ key principles are atomicity and decoupling planning from execution.*
   - [ ] `reload-workspace`: Implement the handler to trigger a reload or
     re-initialisation sequence for the active workspace via Serena's tools.
 
-## **Phase 4: Intelligence & Persistence (Memories)**
+## Phase 4: Intelligence & Persistence (Memories)
 
 *This phase adds long-term memory and project-specific intelligence, allowing
 the agent to adapt to local conventions.*
@@ -237,7 +237,7 @@ the agent to adapt to local conventions.*
   - [ ] `list-memories`: This command will simply read and stream the contents
     of the memory files to `stdout`.
 
-## **Phase 5: Polishing & Productionisation**
+## Phase 5: Polishing & Productionization
 
 *This final phase focuses on robustness, usability, and distribution.*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ banned-from = [
     "enum",
     "unittest.mock",
     "msgspec",
+    "msgspec.json",
 ]
 
 [tool.ruff.lint.flake8-import-conventions.aliases]
@@ -86,6 +87,7 @@ scipy = "sp"
 "collections.abc" = "cabc"
 datetime = "dt"
 "unittest.mock" = "mock"
+msgspec = "ms"
 "msgspec.json" = "msjson"
 typing = "typ"
 

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -31,9 +31,9 @@ async def test_rpc_call_existing_daemon(tmp_path: Path) -> None:
     async with server:
         buf = StringIO()
         await client.rpc_call("project-status", socket_path=sock, stdout=buf)
-        assert msjson.decode(
-            buf.getvalue().encode(), type=ProjectStatus
-        ) == ProjectStatus(message="ok")
+        assert msjson.decode(buf.getvalue(), type=ProjectStatus) == ProjectStatus(
+            message="ok"
+        )
     server.close()
     await server.wait_closed()
 
@@ -82,7 +82,7 @@ async def test_rpc_call_autostart(
     buf = StringIO()
     await client.rpc_call("project-status", socket_path=sock, stdout=buf)
     assert started is not None
-    assert msjson.decode(buf.getvalue().encode(), type=ProjectStatus) == ProjectStatus(
+    assert msjson.decode(buf.getvalue(), type=ProjectStatus) == ProjectStatus(
         message="ok"
     )
     if started and started.is_alive():
@@ -102,7 +102,7 @@ async def test_rpc_call_unknown_method(tmp_path: Path) -> None:
     async with server:
         buf = StringIO()
         await client.rpc_call("nope", socket_path=sock, stdout=buf)
-        err = msjson.decode(buf.getvalue().encode(), type=SchemaError)
+        err = msjson.decode(buf.getvalue(), type=SchemaError)
         assert err.message == "unknown method: nope"
     server.close()
     await server.wait_closed()

--- a/weaver_schemas/diagnostics.py
+++ b/weaver_schemas/diagnostics.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 
 from .primitives import Location  # noqa: TC001
 
 
-class Diagnostic(msgspec.Struct):
+class Diagnostic(ms.Struct, frozen=True):
     """A compiler or linter message."""
 
     location: Location

--- a/weaver_schemas/edits.py
+++ b/weaver_schemas/edits.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 
 from .primitives import Range  # noqa: TC001
 
 
-class CodeEdit(msgspec.Struct):
+class CodeEdit(ms.Struct, frozen=True):
     """A text replacement within a file."""
 
     file: str

--- a/weaver_schemas/error.py
+++ b/weaver_schemas/error.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 
 
-class SchemaError(msgspec.Struct):
+class SchemaError(ms.Struct, frozen=True):
     """A structured error message."""
 
     message: str

--- a/weaver_schemas/primitives.py
+++ b/weaver_schemas/primitives.py
@@ -3,21 +3,21 @@ from __future__ import annotations
 import msgspec as ms
 
 
-class Position(ms.Struct):
+class Position(ms.Struct, frozen=True):
     """A point in a text file."""
 
     line: int
     character: int
 
 
-class Range(ms.Struct):
+class Range(ms.Struct, frozen=True):
     """A span of text between two positions."""
 
     start: Position
     end: Position
 
 
-class Location(ms.Struct):
+class Location(ms.Struct, frozen=True):
     """A range of text within a file."""
 
     file: str

--- a/weaver_schemas/primitives.py
+++ b/weaver_schemas/primitives.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-import msgspec
+import msgspec as ms
 
 
-class Position(msgspec.Struct):
+class Position(ms.Struct):
     """A point in a text file."""
 
     line: int
     character: int
 
 
-class Range(msgspec.Struct):
+class Range(ms.Struct):
     """A span of text between two positions."""
 
     start: Position
     end: Position
 
 
-class Location(msgspec.Struct):
+class Location(ms.Struct):
     """A range of text within a file."""
 
     file: str

--- a/weaver_schemas/references.py
+++ b/weaver_schemas/references.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 
 from .primitives import Location  # noqa: TC001
 
 
-class Symbol(msgspec.Struct):
+class Symbol(ms.Struct, frozen=True):
     """A named code symbol."""
 
     name: str
@@ -16,7 +16,7 @@ class Symbol(msgspec.Struct):
     type: typ.Literal["symbol"] = "symbol"
 
 
-class Reference(msgspec.Struct):
+class Reference(ms.Struct, frozen=True):
     """A reference to a symbol."""
 
     location: Location

--- a/weaver_schemas/reports.py
+++ b/weaver_schemas/reports.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 
 from .diagnostics import Diagnostic  # noqa: TC001
 
 
-class ImpactReport(msgspec.Struct, frozen=True):
+class ImpactReport(ms.Struct, frozen=True):
     """Result of analysing a proposed change."""
 
     diagnostics: tuple[Diagnostic, ...]
     type: typ.Literal["impact"] = "impact"
 
 
-class TestResult(msgspec.Struct):
+class TestResult(ms.Struct, frozen=True):
     """Outcome of a project test run."""
 
     name: str
@@ -23,7 +23,7 @@ class TestResult(msgspec.Struct):
     type: typ.Literal["test-result"] = "test-result"
 
 
-class OnboardingReport(msgspec.Struct):
+class OnboardingReport(ms.Struct, frozen=True):
     """Information gathered during project onboarding."""
 
     details: str

--- a/weaver_schemas/status.py
+++ b/weaver_schemas/status.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 
 
-class ProjectStatus(msgspec.Struct, frozen=True):
+class ProjectStatus(ms.Struct, frozen=True):
     """Basic daemon health indicator."""
 
     message: str

--- a/weaverd/rpc.py
+++ b/weaverd/rpc.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as typ
 
-import msgspec
+import msgspec as ms
 import msgspec.json as msjson
 
 from weaver_schemas.error import SchemaError
@@ -10,7 +10,7 @@ from weaver_schemas.error import SchemaError
 Handler = typ.Callable[..., typ.Awaitable[typ.Any]]
 
 
-class RPCRequest(msgspec.Struct):
+class RPCRequest(ms.Struct, frozen=True):
     """JSON-RPC style request."""
 
     method: str
@@ -33,7 +33,7 @@ class RPCDispatcher:
     async def handle(self, data: bytes) -> bytes:
         try:
             request = msjson.decode(data, type=RPCRequest)
-        except msgspec.DecodeError as exc:
+        except ms.DecodeError as exc:
             return msjson.encode(SchemaError(message=f"invalid request: {exc}"))
 
         handler = self._handlers.get(request.method)

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -29,7 +29,9 @@ async def handle_client(
         while data := await reader.readline():
             try:
                 response = await dispatcher.handle(data.rstrip())
-            except Exception as exc:  # noqa: BLE001 pragma: no cover - fallback
+            except Exception as exc:  # pragma: no cover - fallback
+                if isinstance(exc, asyncio.CancelledError | KeyboardInterrupt):
+                    raise
                 response = msjson.encode(SchemaError(message=str(exc)))
             writer.write(response + b"\n")
             await writer.drain()

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import getpass
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -12,6 +13,8 @@ from weaver_schemas.error import SchemaError
 from weaver_schemas.status import ProjectStatus
 
 from .rpc import RPCDispatcher
+
+logger = logging.getLogger(__name__)
 
 
 def default_socket_path() -> Path:
@@ -30,8 +33,9 @@ async def handle_client(
             try:
                 response = await dispatcher.handle(data.rstrip())
             except Exception as exc:  # pragma: no cover - fallback
-                if isinstance(exc, asyncio.CancelledError | KeyboardInterrupt):
+                if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt)):  # noqa: UP038
                     raise
+                logger.exception("Unhandled RPC error")
                 response = msjson.encode(SchemaError(message=str(exc)))
             writer.write(response + b"\n")
             await writer.drain()

--- a/weaverd/unittests/test_server.py
+++ b/weaverd/unittests/test_server.py
@@ -35,7 +35,7 @@ async def test_server_echoes_status(tmp_path: Path) -> None:
         writer.write(msjson.encode({"method": "project-status"}) + b"\n")
         await writer.drain()
         data = await reader.readline()
-        assert msjson.decode(data.rstrip(), type=ProjectStatus) == ProjectStatus(
+        assert msjson.decode(data.rstrip(b"\n"), type=ProjectStatus) == ProjectStatus(
             message="ok"
         )
         writer.close()
@@ -62,9 +62,9 @@ async def test_server_handles_multiple_requests(tmp_path: Path) -> None:
             )
             await writer.drain()
             data = await reader.readline()
-            assert msjson.decode(data.rstrip(), type=ProjectStatus) == ProjectStatus(
-                message=str(i)
-            )
+            assert msjson.decode(
+                data.rstrip(b"\n"), type=ProjectStatus
+            ) == ProjectStatus(message=str(i))
         writer.close()
         await writer.wait_closed()
     server.close()


### PR DESCRIPTION
## Summary
- remove redundant bold markers and fix URLs in `docs/roadmap.md`
- ban `msgspec.json` from from-imports and alias `msgspec` as `ms`
- freeze various schema structs to prevent accidental mutation
- improve error handling in `weaverd.server`
- adjust tests for `msjson` API

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make nixie` *(fails: error: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688153229b48832298c3895ff811b2a4

## Summary by Sourcery

Enforce immutability for schema structs, tighten import conventions, improve error handling in server, update documentation formatting, and adjust tests for the new JSON decoding API.

Enhancements:
- Make all msgspec-based schema Struct classes frozen to prevent accidental mutations
- Alias msgspec as ms and ban msgspec.json from from-imports in lint configuration
- Improve server error handling to re-raise cancellation and interruption exceptions

Build:
- Update pyproject.toml to tighten import-conventions and alias msgspec as ms/msjson

Documentation:
- Remove redundant bold markers and correct UV URLs in roadmap documentation

Tests:
- Adjust unit tests to use msjson.decode without extra encoding and update rstrip usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of trailing newlines in server response tests for more precise decoding.
  * Fixed test cases to pass string data directly for JSON decoding without unnecessary encoding.

* **Refactor**
  * Updated import statements to consistently use module aliases and improved immutability for data classes.
  * Standardized class inheritance and made several data structures immutable for greater reliability.

* **New Features**
  * Added logging for unhandled exceptions during server request handling to improve error visibility.

* **Documentation**
  * Improved roadmap formatting, corrected terminology, and updated links for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->