### PR TITLE
Fix missing dependency exit code

### DIFF
--- a/features/conftest.py
+++ b/features/conftest.py
@@ -3,6 +3,7 @@ import collections.abc as cabc
 import multiprocessing as mp
 import os
 import time
+import typing as typ
 from pathlib import Path
 
 import pytest

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -1,4 +1,5 @@
 import json
+import typing as typ
 from pathlib import Path
 
 import msgspec
@@ -77,7 +78,9 @@ def missing_dependency(monkeypatch):
 @then("the command fails with a missing dependency message")
 def check_missing_dep(context: Context) -> None:
     result = context["result"]
-    assert result.exit_code == 0
+    # When a required dependency like serena-agent is absent, the command
+    # should fail, signalling the problem via a non-zero exit code.
+    assert result.exit_code != 0
     out = (result.stdout + result.stderr).lower()
     assert "serena-agent" in out or "missing dependency" in out
 

--- a/features/steps/test_project_status.py
+++ b/features/steps/test_project_status.py
@@ -1,3 +1,5 @@
+import typing as typ
+
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -9,6 +9,7 @@ import typing as typ
 from pathlib import Path  # noqa: TC003
 
 import anyio
+import msgspec
 import msgspec.json as msjson
 import typer
 
@@ -65,6 +66,7 @@ async def rpc_call(
         raise typer.Exit(1) from exc
 
     reader, writer = await asyncio.open_unix_connection(str(path))
+    error = False
     try:
         writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
         await writer.drain()
@@ -76,6 +78,16 @@ async def rpc_call(
             else:
                 stdout.write(data.decode())
             stdout.flush()
+            try:
+                record = msjson.decode(data.rstrip())
+            except msgspec.DecodeError:
+                continue
+            if isinstance(record, dict) and record.get("type") == "error":
+                msg = str(record.get("message", "")).lower()
+                if "serena-agent" in msg or "missing dependency" in msg:
+                    error = True
     finally:
         writer.close()
         await writer.wait_closed()
+    if error:
+        raise typer.Exit(1)

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -81,6 +81,33 @@ async def ensure_daemon_running(socket_path: Path) -> None:
     raise RuntimeError("weaverd failed to start")
 
 
+def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:
+    """Write ``data`` to ``stdout`` and detect dependency errors."""
+
+    buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
+    if buf is not None:
+        buf.write(data)
+    else:
+        stdout.write(data.decode())
+    stdout.flush()
+
+    try:
+        record = msjson.decode(data.rstrip())
+    except msgspec.DecodeError:
+        return False
+    return bool(isinstance(record, dict) and _check_dependency_error(record))
+
+
+async def _stream_response(reader: asyncio.StreamReader, stdout: typ.TextIO) -> bool:
+    """Stream lines from ``reader`` to ``stdout`` and flag dependency errors."""
+
+    error = False
+    while data := await reader.readline():
+        if _process_response_line(data, stdout):
+            error = True
+    return error
+
+
 async def rpc_call(
     method: str,
     params: dict[str, typ.Any] | None = None,
@@ -102,19 +129,7 @@ async def rpc_call(
         writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
         await writer.drain()
         writer.write_eof()
-        while data := await reader.readline():
-            buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
-            if buf is not None:
-                buf.write(data)
-            else:
-                stdout.write(data.decode())
-            stdout.flush()
-            try:
-                record = msjson.decode(data.rstrip())
-            except msgspec.DecodeError:
-                continue
-            if isinstance(record, dict) and _check_dependency_error(record):
-                error = True
+        error = await _stream_response(reader, stdout)
     finally:
         writer.close()
         await writer.wait_closed()

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import io  # noqa: TC003
 import os
 import subprocess
@@ -16,6 +17,36 @@ import typer
 from weaverd.server import default_socket_path
 
 from .sockets import can_connect
+
+
+class DependencyErrorCode(enum.StrEnum):
+    """Enumerate dependency-related error codes."""
+
+    MISSING_DEPENDENCY = "MISSING_DEPENDENCY"
+    SERENA_AGENT_NOT_FOUND = "SERENA_AGENT_NOT_FOUND"
+    DEPENDENCY_UNAVAILABLE = "DEPENDENCY_UNAVAILABLE"
+    DEPENDENCY_VERSION_MISMATCH = "DEPENDENCY_VERSION_MISMATCH"
+
+
+def _check_dependency_error(record: dict[str, typ.Any]) -> bool:
+    """Return ``True`` if ``record`` signals a missing dependency."""
+
+    if record.get("type") != "error":
+        return False
+
+    code = record.get("error_code") or record.get("code")
+
+    match code:
+        case (
+            DependencyErrorCode.MISSING_DEPENDENCY
+            | DependencyErrorCode.SERENA_AGENT_NOT_FOUND
+            | DependencyErrorCode.DEPENDENCY_UNAVAILABLE
+            | DependencyErrorCode.DEPENDENCY_VERSION_MISMATCH
+        ):
+            return True
+        case _:
+            msg = str(record.get("message", "")).lower()
+            return "serena-agent" in msg or "missing dependency" in msg
 
 
 def discover_socket() -> Path:
@@ -82,10 +113,8 @@ async def rpc_call(
                 record = msjson.decode(data.rstrip())
             except msgspec.DecodeError:
                 continue
-            if isinstance(record, dict) and record.get("type") == "error":
-                msg = str(record.get("message", "")).lower()
-                if "serena-agent" in msg or "missing dependency" in msg:
-                    error = True
+            if isinstance(record, dict) and _check_dependency_error(record):
+                error = True
     finally:
         writer.close()
         await writer.wait_closed()

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -1,6 +1,6 @@
 import asyncio
 import multiprocessing as mp
-from io import StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
 
 import msgspec.json as msjson
@@ -106,3 +106,22 @@ async def test_rpc_call_unknown_method(tmp_path: Path) -> None:
         assert err.message == "unknown method: nope"
     server.close()
     await server.wait_closed()
+
+
+def test_process_response_line_detects_errors() -> None:
+    out = StringIO()
+    line = (
+        msjson.encode({"type": "error", "message": "missing dependency serena-agent"})
+        + b"\n"
+    )
+    assert client._process_response_line(line, out)
+    assert "serena-agent" in out.getvalue()
+
+
+def test_process_response_line_buffered_stdout() -> None:
+    buf = BytesIO()
+    out = TextIOWrapper(buf, encoding="utf-8")
+    line = msjson.encode({"type": "result", "value": 42}) + b"\n"
+    assert not client._process_response_line(line, out)
+    out.flush()
+    assert buf.getvalue() == line


### PR DESCRIPTION
## Summary
- expect a failing exit code for missing dependencies
- flag serena-agent errors in `rpc_call`
- update typing aliasing in tests
- adjust unit tests for msgspec alias

## Testing
- `make fmt`
- `make lint`
- `make check-fmt`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688162e7633c83228381231fa47830e1

## Summary by Sourcery

Detect and handle missing dependencies in RPC responses by introducing dedicated error enumeration and streaming logic, and ensure commands exit with a non-zero code when such errors occur

New Features:
- Add DependencyErrorCode enum to categorize various dependency-related errors

Enhancements:
- Implement _process_response_line and _stream_response to stream RPC output and flag dependency errors
- Modify rpc_call to leverage the new streaming logic and exit with a non-zero code on missing dependencies
- Update BDD test to expect a failing exit code when dependencies are missing

Tests:
- Add unit tests for _process_response_line to verify error detection and buffered stdout handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection for missing dependencies, ensuring the application exits with an error status when required components are not found.

* **Tests**
  * Updated test assertions and comments to reflect expected error behavior when dependencies are missing.
  * Standardized import aliases in test files for better consistency.

* **Style**
  * Unified import alias usage for typing and JSON modules across the codebase for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->