### PR TITLE
Fix malformed JSON scenario

### DIFF
--- a/features/conftest.py
+++ b/features/conftest.py
@@ -3,7 +3,7 @@ import collections.abc as cabc
 import multiprocessing as mp
 import os
 import time
-import typing as t
+import typing as typ
 from pathlib import Path
 
 import pytest
@@ -16,7 +16,7 @@ from weaverd.server import start_server
 @pytest.fixture()
 def runtime_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> cabc.Generator[dict[str, t.Any], None, None]:
+) -> cabc.Generator[dict[str, typ.Any], None, None]:
     os.environ["XDG_RUNTIME_DIR"] = str(tmp_path)
     sock = client.discover_socket()
     processes: list[mp.Process] = []
@@ -51,7 +51,7 @@ def runtime_dir(
 
     ctx = {"sock": sock, "processes": processes}
 
-    def register(fn: cabc.Callable[[RPCDispatcher], None]) -> dict[str, t.Any]:
+    def register(fn: cabc.Callable[[RPCDispatcher], None]) -> dict[str, typ.Any]:
         handler["func"] = fn
         return ctx
 

--- a/features/conftest.py
+++ b/features/conftest.py
@@ -3,11 +3,11 @@ import collections.abc as cabc
 import multiprocessing as mp
 import os
 import time
-import typing as typ
 from pathlib import Path
 
 import pytest
 
+from features.types import Context
 from weaver import client
 from weaverd.rpc import RPCDispatcher
 from weaverd.server import start_server
@@ -16,7 +16,7 @@ from weaverd.server import start_server
 @pytest.fixture()
 def runtime_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> cabc.Generator[dict[str, typ.Any], None, None]:
+) -> cabc.Generator[Context, None, None]:
     os.environ["XDG_RUNTIME_DIR"] = str(tmp_path)
     sock = client.discover_socket()
     processes: list[mp.Process] = []
@@ -49,9 +49,9 @@ def runtime_dir(
 
     monkeypatch.setattr(client, "spawn_daemon", spawn_daemon)
 
-    ctx = {"sock": sock, "processes": processes}
+    ctx: Context = {"sock": sock, "processes": processes}
 
-    def register(fn: cabc.Callable[[RPCDispatcher], None]) -> dict[str, typ.Any]:
+    def register(fn: cabc.Callable[[RPCDispatcher], None]) -> Context:
         handler["func"] = fn
         return ctx
 

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -1,5 +1,5 @@
 import json
-import typing as t
+import typing as typ
 from pathlib import Path
 
 from pytest_bdd import given, scenarios, then, when
@@ -14,7 +14,7 @@ scenarios("../onboard_project.feature")
 
 
 @given("a temporary runtime dir", target_fixture="context")
-def runtime_dir(runtime_dir: dict[str, t.Any]) -> dict[str, t.Any]:
+def runtime_dir(runtime_dir: dict[str, typ.Any]) -> dict[str, typ.Any]:
     def setup(dispatcher: RPCDispatcher) -> None:
         @dispatcher.register("onboard-project")
         async def onboard() -> OnboardingReport:  # pragma: no cover - stub
@@ -26,7 +26,7 @@ def runtime_dir(runtime_dir: dict[str, t.Any]) -> dict[str, t.Any]:
 
 
 @given("an invalid project structure")
-def invalid_project(context: dict[str, t.Any], monkeypatch) -> None:
+def invalid_project(context: dict[str, typ.Any], monkeypatch) -> None:
     def fail_spawn(_: Path) -> None:  # pragma: no cover - stub
         pass
 
@@ -34,7 +34,7 @@ def invalid_project(context: dict[str, t.Any], monkeypatch) -> None:
 
 
 @given("the server is unavailable")
-def server_unavailable(context: dict[str, t.Any], monkeypatch) -> None:
+def server_unavailable(context: dict[str, typ.Any], monkeypatch) -> None:
     def noop(_: Path) -> None:  # pragma: no cover - stub
         pass
 
@@ -42,17 +42,20 @@ def server_unavailable(context: dict[str, t.Any], monkeypatch) -> None:
 
 
 @given("the server returns malformed output")
-def server_malformed(context: dict[str, t.Any]) -> None:
+def server_malformed(context: dict[str, typ.Any]) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
-        @dispatcher.register("onboard-project")
-        async def onboard() -> str:  # pragma: no cover - stub
-            return "MALFORMED OUTPUT"
+        async def malformed(_: bytes) -> bytes:
+            # Intentionally bypass msgspec encoding so the client
+            # receives bytes that are not valid JSON.
+            return b"MALFORMED OUTPUT"
+
+        dispatcher.handle = malformed  # type: ignore[assignment]
 
     context["register"](setup)
 
 
 @given("the onboarding tool raises an error")
-def tool_error(context: dict[str, t.Any], monkeypatch) -> None:
+def tool_error(context: dict[str, typ.Any], monkeypatch) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
         class FailingTool:
             def apply(self) -> str:  # pragma: no cover - stub
@@ -72,7 +75,7 @@ def missing_dependency(monkeypatch):
 
 
 @then("the command fails with a missing dependency message")
-def check_missing_dep(context: dict[str, t.Any]) -> None:
+def check_missing_dep(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code == 0
     out = (result.stdout + result.stderr).lower()
@@ -80,14 +83,14 @@ def check_missing_dep(context: dict[str, t.Any]) -> None:
 
 
 @when("I invoke the onboard-project command")
-def invoke(context: dict[str, t.Any]) -> None:
+def invoke(context: dict[str, typ.Any]) -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["onboard-project"])
     context["result"] = result
 
 
 @then("the output includes onboarding details")
-def check(context: dict[str, t.Any]) -> None:
+def check(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert result.stdout.strip()
@@ -96,7 +99,7 @@ def check(context: dict[str, t.Any]) -> None:
 
 
 @then("the command fails with an error message")
-def check_error(context: dict[str, t.Any]) -> None:
+def check_error(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code != 0
     err = result.stderr.lower()
@@ -104,7 +107,7 @@ def check_error(context: dict[str, t.Any]) -> None:
 
 
 @then("an error report is produced")
-def check_report(context: dict[str, t.Any]) -> None:
+def check_report(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code == 0
     line = result.stdout.splitlines()[0]
@@ -113,7 +116,7 @@ def check_report(context: dict[str, t.Any]) -> None:
 
 
 @then("the output indicates the server is unavailable")
-def check_unavailable(context: dict[str, t.Any]) -> None:
+def check_unavailable(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code != 0
     out = result.stderr.lower()
@@ -121,7 +124,7 @@ def check_unavailable(context: dict[str, t.Any]) -> None:
 
 
 @then("the output is malformed")
-def check_malformed(context: dict[str, t.Any]) -> None:
+def check_malformed(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert "malformed output" in result.stdout.lower()

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -1,10 +1,11 @@
 import json
-import typing as typ
 from pathlib import Path
 
+import msgspec
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 
+from features.types import Context
 from weaver.cli import app
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
@@ -14,7 +15,7 @@ scenarios("../onboard_project.feature")
 
 
 @given("a temporary runtime dir", target_fixture="context")
-def runtime_dir(runtime_dir: dict[str, typ.Any]) -> dict[str, typ.Any]:
+def runtime_dir(runtime_dir: Context) -> Context:
     def setup(dispatcher: RPCDispatcher) -> None:
         @dispatcher.register("onboard-project")
         async def onboard() -> OnboardingReport:  # pragma: no cover - stub
@@ -26,7 +27,7 @@ def runtime_dir(runtime_dir: dict[str, typ.Any]) -> dict[str, typ.Any]:
 
 
 @given("an invalid project structure")
-def invalid_project(context: dict[str, typ.Any], monkeypatch) -> None:
+def invalid_project(context: Context, monkeypatch) -> None:
     def fail_spawn(_: Path) -> None:  # pragma: no cover - stub
         pass
 
@@ -34,7 +35,7 @@ def invalid_project(context: dict[str, typ.Any], monkeypatch) -> None:
 
 
 @given("the server is unavailable")
-def server_unavailable(context: dict[str, typ.Any], monkeypatch) -> None:
+def server_unavailable(context: Context, monkeypatch) -> None:
     def noop(_: Path) -> None:  # pragma: no cover - stub
         pass
 
@@ -42,20 +43,19 @@ def server_unavailable(context: dict[str, typ.Any], monkeypatch) -> None:
 
 
 @given("the server returns malformed output")
-def server_malformed(context: dict[str, typ.Any]) -> None:
+def server_malformed(context: Context) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
-        async def malformed(_: bytes) -> bytes:
-            # Intentionally bypass msgspec encoding so the client
-            # receives bytes that are not valid JSON.
-            return b"MALFORMED OUTPUT"
-
-        dispatcher.handle = malformed  # type: ignore[assignment]
+        @dispatcher.register("onboard-project")
+        async def malformed() -> msgspec.Raw:
+            # Return raw bytes that do not form valid JSON so the
+            # client hits a decode error.
+            return msgspec.Raw(b"MALFORMED OUTPUT")
 
     context["register"](setup)
 
 
 @given("the onboarding tool raises an error")
-def tool_error(context: dict[str, typ.Any], monkeypatch) -> None:
+def tool_error(context: Context, monkeypatch) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
         class FailingTool:
             def apply(self) -> str:  # pragma: no cover - stub
@@ -75,7 +75,7 @@ def missing_dependency(monkeypatch):
 
 
 @then("the command fails with a missing dependency message")
-def check_missing_dep(context: dict[str, typ.Any]) -> None:
+def check_missing_dep(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
     out = (result.stdout + result.stderr).lower()
@@ -83,14 +83,14 @@ def check_missing_dep(context: dict[str, typ.Any]) -> None:
 
 
 @when("I invoke the onboard-project command")
-def invoke(context: dict[str, typ.Any]) -> None:
+def invoke(context: Context) -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["onboard-project"])
     context["result"] = result
 
 
 @then("the output includes onboarding details")
-def check(context: dict[str, typ.Any]) -> None:
+def check(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert result.stdout.strip()
@@ -99,7 +99,7 @@ def check(context: dict[str, typ.Any]) -> None:
 
 
 @then("the command fails with an error message")
-def check_error(context: dict[str, typ.Any]) -> None:
+def check_error(context: Context) -> None:
     result = context["result"]
     assert result.exit_code != 0
     err = result.stderr.lower()
@@ -107,7 +107,7 @@ def check_error(context: dict[str, typ.Any]) -> None:
 
 
 @then("an error report is produced")
-def check_report(context: dict[str, typ.Any]) -> None:
+def check_report(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
     line = result.stdout.splitlines()[0]
@@ -116,7 +116,7 @@ def check_report(context: dict[str, typ.Any]) -> None:
 
 
 @then("the output indicates the server is unavailable")
-def check_unavailable(context: dict[str, typ.Any]) -> None:
+def check_unavailable(context: Context) -> None:
     result = context["result"]
     assert result.exit_code != 0
     out = result.stderr.lower()
@@ -124,7 +124,7 @@ def check_unavailable(context: dict[str, typ.Any]) -> None:
 
 
 @then("the output is malformed")
-def check_malformed(context: dict[str, typ.Any]) -> None:
+def check_malformed(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert "malformed output" in result.stdout.lower()

--- a/features/steps/test_project_status.py
+++ b/features/steps/test_project_status.py
@@ -1,8 +1,7 @@
-import typing as typ
-
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 
+from features.types import Context
 from weaver.cli import app
 from weaver_schemas.status import ProjectStatus
 from weaverd.rpc import RPCDispatcher
@@ -11,7 +10,7 @@ scenarios("../project_status.feature")
 
 
 @given("a temporary runtime dir", target_fixture="context")
-def runtime_dir(runtime_dir: dict[str, typ.Any]) -> dict[str, typ.Any]:
+def runtime_dir(runtime_dir: Context) -> Context:
     def setup(dispatcher: RPCDispatcher) -> None:
         @dispatcher.register("project-status")
         async def status() -> ProjectStatus:  # pragma: no cover - stub
@@ -22,14 +21,14 @@ def runtime_dir(runtime_dir: dict[str, typ.Any]) -> dict[str, typ.Any]:
 
 
 @when("I invoke the project-status command")
-def invoke(context: dict[str, typ.Any]) -> None:
+def invoke(context: Context) -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["project-status"])
     context["result"] = result
 
 
 @then("the output includes a project status line")
-def check(context: dict[str, typ.Any]) -> None:
+def check(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert '"message":"ok"' in result.stdout

--- a/features/steps/test_project_status.py
+++ b/features/steps/test_project_status.py
@@ -1,4 +1,4 @@
-import typing as t
+import typing as typ
 
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
@@ -11,7 +11,7 @@ scenarios("../project_status.feature")
 
 
 @given("a temporary runtime dir", target_fixture="context")
-def runtime_dir(runtime_dir: dict[str, t.Any]) -> dict[str, t.Any]:
+def runtime_dir(runtime_dir: dict[str, typ.Any]) -> dict[str, typ.Any]:
     def setup(dispatcher: RPCDispatcher) -> None:
         @dispatcher.register("project-status")
         async def status() -> ProjectStatus:  # pragma: no cover - stub
@@ -22,14 +22,14 @@ def runtime_dir(runtime_dir: dict[str, t.Any]) -> dict[str, t.Any]:
 
 
 @when("I invoke the project-status command")
-def invoke(context: dict[str, t.Any]) -> None:
+def invoke(context: dict[str, typ.Any]) -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["project-status"])
     context["result"] = result
 
 
 @then("the output includes a project status line")
-def check(context: dict[str, t.Any]) -> None:
+def check(context: dict[str, typ.Any]) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert '"message":"ok"' in result.stdout

--- a/features/types.py
+++ b/features/types.py
@@ -1,0 +1,3 @@
+import typing as typ
+
+Context = dict[str, typ.Any]

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
+import typing as typ
 
-if t.TYPE_CHECKING:
+if typ.TYPE_CHECKING:
     from pathlib import Path
 
+import msgspec.json as msjson
 import pytest
-from msgspec import json
 
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
@@ -35,10 +35,10 @@ async def test_onboard_project(tmp_path: Path) -> None:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_unix_connection(str(sock)), timeout=5.0
             )
-            writer.write(json.encode({"method": "onboard-project"}) + b"\n")
+            writer.write(msjson.encode({"method": "onboard-project"}) + b"\n")
             await writer.drain()
             data = await asyncio.wait_for(reader.readline(), timeout=5.0)
-            report = json.decode(data.rstrip(), type=OnboardingReport)
+            report = msjson.decode(data.rstrip(), type=OnboardingReport)
             text = report.details.lower()
             assert "viewing" in text and "project" in text
             assert len(report.details) > 20
@@ -70,10 +70,10 @@ async def test_onboard_failure(tmp_path: Path) -> None:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_unix_connection(str(sock)), timeout=5.0
             )
-            writer.write(json.encode({"method": "onboard-project"}) + b"\n")
+            writer.write(msjson.encode({"method": "onboard-project"}) + b"\n")
             await writer.drain()
             data = await asyncio.wait_for(reader.readline(), timeout=5.0)
-            error = json.decode(data.rstrip())
+            error = msjson.decode(data.rstrip())
             assert error.get("type") == "error"
         finally:
             writer.close()


### PR DESCRIPTION
## Summary
- simulate bad JSON from server in onboarding tests
- align typing import aliases with repo conventions
- fix lint in unit test imports

## Testing
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68816386dd908322b6a79847120bad16

## Summary by Sourcery

Simulate malformed JSON responses in onboarding tests, standardize typing alias usage, and switch unit tests to msjson encoding/decoding while addressing lint issues.

New Features:
- Add a malformed JSON scenario in onboarding feature tests by overriding the RPC dispatcher to return invalid bytes

Enhancements:
- Replace all t.Any typing annotations with typ.Any across feature step definitions and conftest
- Switch JSON encoding and decoding in unit tests from the json module to msjson for consistency

Tests:
- Fix lint errors in test imports following the alias change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type clarity and consistency across test and step definition files by introducing and using a dedicated context type.
  * Updated import aliases for external libraries to maintain naming consistency.

* **Chores**
  * Removed unused imports to streamline the codebase.

* **Tests**
  * No changes to test logic or behavior; updates are limited to type annotations and import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->