### PR TITLE
Fix missing dependency exit code

### DIFF
--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -77,7 +77,9 @@ def missing_dependency(monkeypatch):
 @then("the command fails with a missing dependency message")
 def check_missing_dep(context: Context) -> None:
     result = context["result"]
-    assert result.exit_code == 0
+    # When a required dependency like serena-agent is absent, the command
+    # should fail with exit code 1.
+    assert result.exit_code == 1
     out = (result.stdout + result.stderr).lower()
     assert "serena-agent" in out or "missing dependency" in out
 

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -52,7 +52,11 @@ async def ensure_daemon_running(socket_path: Path) -> None:
 
 
 def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:
-    """Write ``data`` to ``stdout`` and detect dependency errors."""
+    """Write ``data`` to ``stdout`` and detect dependency errors.
+
+    Returns:
+        bool: ``True`` if a dependency error was detected, ``False`` otherwise.
+    """
 
     text = data.decode(
         encoding=getattr(stdout, "encoding", "utf-8") or "utf-8",

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import io  # noqa: TC003
 import logging
 import os
 import subprocess
@@ -55,22 +54,17 @@ async def ensure_daemon_running(socket_path: Path) -> None:
 def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:
     """Write ``data`` to ``stdout`` and detect dependency errors."""
 
-    buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
-    if buf is not None:
-        buf.write(data)
-    else:
-        stdout.write(
-            data.decode(
-                encoding=getattr(stdout, "encoding", "utf-8") or "utf-8",
-                errors="replace",
-            )
-        )
+    text = data.decode(
+        encoding=getattr(stdout, "encoding", "utf-8") or "utf-8",
+        errors="replace",
+    )
+    stdout.write(text)
     stdout.flush()
 
     try:
         record = msjson.decode(data.rstrip())
     except msgspec.DecodeError as exc:
-        logging.debug("Failed to decode response line: %r: %s", data, exc)
+        logging.warning("Failed to decode response line: %r: %s", data, exc)
         return False
     return bool(isinstance(record, dict) and is_dependency_error(record))
 

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io  # noqa: TC003
+import logging
 import os
 import subprocess
 import sys
@@ -9,11 +10,13 @@ import typing as typ
 from pathlib import Path  # noqa: TC003
 
 import anyio
+import msgspec
 import msgspec.json as msjson
 import typer
 
 from weaverd.server import default_socket_path
 
+from .errors import is_dependency_error
 from .sockets import can_connect
 
 
@@ -49,6 +52,39 @@ async def ensure_daemon_running(socket_path: Path) -> None:
     raise RuntimeError("weaverd failed to start")
 
 
+def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:
+    """Write ``data`` to ``stdout`` and detect dependency errors."""
+
+    buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
+    if buf is not None:
+        buf.write(data)
+    else:
+        stdout.write(
+            data.decode(
+                encoding=getattr(stdout, "encoding", "utf-8") or "utf-8",
+                errors="replace",
+            )
+        )
+    stdout.flush()
+
+    try:
+        record = msjson.decode(data.rstrip())
+    except msgspec.DecodeError as exc:
+        logging.debug("Failed to decode response line: %r: %s", data, exc)
+        return False
+    return bool(isinstance(record, dict) and is_dependency_error(record))
+
+
+async def _stream_response(reader: asyncio.StreamReader, stdout: typ.TextIO) -> bool:
+    """Stream lines from ``reader`` to ``stdout`` and flag dependency errors."""
+
+    error = False
+    while data := await reader.readline():
+        if _process_response_line(data, stdout):
+            error = True
+    return error
+
+
 async def rpc_call(
     method: str,
     params: dict[str, typ.Any] | None = None,
@@ -65,17 +101,14 @@ async def rpc_call(
         raise typer.Exit(1) from exc
 
     reader, writer = await asyncio.open_unix_connection(str(path))
+    error = False
     try:
         writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
         await writer.drain()
         writer.write_eof()
-        while data := await reader.readline():
-            buf: io.BufferedWriter | None = getattr(stdout, "buffer", None)
-            if buf is not None:
-                buf.write(data)
-            else:
-                stdout.write(data.decode())
-            stdout.flush()
+        error = await _stream_response(reader, stdout)
     finally:
         writer.close()
         await writer.wait_closed()
+    if error:
+        raise typer.Exit(1)

--- a/weaver/errors.py
+++ b/weaver/errors.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import enum
+import logging
+import re
+import typing as typ
+
+__all__ = ["DependencyErrorCode", "is_dependency_error"]
+
+
+class DependencyErrorCode(enum.StrEnum):
+    """Enumerate dependency-related error codes."""
+
+    MISSING_DEPENDENCY = "MISSING_DEPENDENCY"
+    SERENA_AGENT_NOT_FOUND = "SERENA_AGENT_NOT_FOUND"
+    DEPENDENCY_UNAVAILABLE = "DEPENDENCY_UNAVAILABLE"
+    DEPENDENCY_VERSION_MISMATCH = "DEPENDENCY_VERSION_MISMATCH"
+
+
+_missing_dep_pattern = re.compile(r"\bmissing dependency\b[:\-]?\s*\w+", re.IGNORECASE)
+_serena_agent_pattern = re.compile(
+    r"\bserena[- ]agent\b.*(not found|unavailable|missing)", re.IGNORECASE
+)
+logger = logging.getLogger(__name__)
+
+
+def is_dependency_error(record: dict[str, typ.Any]) -> bool:
+    """Return ``True`` if ``record`` signals a dependency problem."""
+
+    if record.get("type") != "error":
+        return False
+
+    code = record.get("error_code") or record.get("code")
+
+    match code:
+        case (
+            DependencyErrorCode.MISSING_DEPENDENCY
+            | DependencyErrorCode.SERENA_AGENT_NOT_FOUND
+            | DependencyErrorCode.DEPENDENCY_UNAVAILABLE
+            | DependencyErrorCode.DEPENDENCY_VERSION_MISMATCH
+        ):
+            return True
+        case _:
+            msg = str(record.get("message", ""))
+            if _missing_dep_pattern.search(msg) or _serena_agent_pattern.search(msg):
+                return True
+
+    return False

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -1,12 +1,13 @@
 import asyncio
 import multiprocessing as mp
-from io import StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
 
 import msgspec.json as msjson
 import pytest
 
 from weaver import client
+from weaver.errors import DependencyErrorCode
 from weaver_schemas.error import SchemaError
 from weaver_schemas.status import ProjectStatus
 from weaverd.rpc import RPCDispatcher
@@ -106,3 +107,34 @@ async def test_rpc_call_unknown_method(tmp_path: Path) -> None:
         assert err.message == "unknown method: nope"
     server.close()
     await server.wait_closed()
+
+
+@pytest.mark.parametrize("code", list(DependencyErrorCode))
+def test_process_response_line_detects_error_codes(code: DependencyErrorCode) -> None:
+    out = StringIO()
+    line = msjson.encode({"type": "error", "error_code": code}) + b"\n"
+    assert client._process_response_line(line, out)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "missing dependency serena-agent",
+        "missing dependency: foo-lib",
+        "Serena-Agent not found",
+        "serena agent unavailable",
+    ],
+)
+def test_process_response_line_detects_error_messages(message: str) -> None:
+    out = StringIO()
+    line = msjson.encode({"type": "error", "message": message}) + b"\n"
+    assert client._process_response_line(line, out)
+
+
+def test_process_response_line_buffered_stdout() -> None:
+    buf = BytesIO()
+    out = TextIOWrapper(buf, encoding="utf-8")
+    line = msjson.encode({"type": "result", "value": 42}) + b"\n"
+    assert not client._process_response_line(line, out)
+    out.flush()
+    assert buf.getvalue() == line


### PR DESCRIPTION
## Summary
- expect exit code 1 when dependencies are missing
- factor dependency error detection into shared utils
- log JSON decode issues for better debugging
- expand tests for dependency error codes and messages

## Testing
- `make fmt`
- `make lint`
- `make check-fmt`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688162e7633c83228381231fa47830e1

## Summary by Sourcery

Improve dependency error handling by introducing a shared detection utility and ensuring the CLI exits with code 1 when missing dependencies are encountered. Refactor RPC response streaming to use the new utility and log JSON decode failures for better debugging. Update tests and feature scenarios accordingly to cover error codes, messages, and exit behaviors.

New Features:
- Ensure CLI exits with status 1 on missing dependencies
- Add shared dependency error detection via DependencyErrorCode enum and is_dependency_error function

Enhancements:
- Refactor rpc_call to stream responses with _stream_response and detect errors
- Log JSON decode failures for troubleshooting
- Switch weaverd tests to use msjson for encoding/decoding

Tests:
- Expand client tests for dependency error codes, messages, and buffered stdout
- Update feature tests to expect exit code 1 for missing dependencies and fix type annotations

Chores:
- Introduce weaver/errors.py to consolidate dependency error logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated handling of missing dependency scenarios to ensure commands fail with the correct exit code when required dependencies are absent.

* **New Features**
  * Improved detection and reporting of dependency-related errors in command output.
  * Enhanced error messages for missing or unavailable dependencies.

* **Tests**
  * Added new tests to verify accurate detection and reporting of dependency errors in response processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->