### PR TITLE
Address review comments on client logging and tests

### DIFF
--- a/weaver/client.py
+++ b/weaver/client.py
@@ -18,6 +18,8 @@ from weaverd.server import default_socket_path
 from .errors import is_dependency_error
 from .sockets import can_connect
 
+logger = logging.getLogger(__name__)
+
 
 def discover_socket() -> Path:
     """Return the daemon socket path."""
@@ -68,7 +70,7 @@ def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:
     try:
         record = msjson.decode(data.rstrip())
     except ms.DecodeError as exc:
-        logging.warning("Failed to decode response line: %r: %s", data, exc)
+        logger.warning("Failed to decode response line: %r: %s", data, exc)
         return False
     return bool(isinstance(record, dict) and is_dependency_error(record))
 

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import multiprocessing as mp
+import typing as typ
 from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
 
@@ -114,6 +115,33 @@ def test_process_response_line_detects_error_codes(code: DependencyErrorCode) ->
     out = StringIO()
     line = msjson.encode({"type": "error", "error_code": code}) + b"\n"
     assert client._process_response_line(line, out)
+
+
+@pytest.mark.parametrize("code", list(DependencyErrorCode))
+def test_process_response_line_detects_code_key(code: DependencyErrorCode) -> None:
+    out = StringIO()
+    line = msjson.encode({"type": "error", "code": code}) + b"\n"
+    assert client._process_response_line(line, out)
+
+
+def test_process_response_line_non_dependency_error_code() -> None:
+    out = StringIO()
+    line = msjson.encode({"type": "error", "error_code": "SOME_OTHER_ERROR"}) + b"\n"
+    assert not client._process_response_line(line, out)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"type": "info", "message": "not an error"},
+        {"foo": "bar"},
+        {},
+    ],
+)
+def test_process_response_line_non_error_type(payload: dict[str, typ.Any]) -> None:
+    out = StringIO()
+    line = msjson.encode(payload) + b"\n"
+    assert not client._process_response_line(line, out)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- use a module level logger in client
- extend `_process_response_line` tests for negative scenarios
- ensure the fallback `code` key path is covered

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6883abb0f24c8322a63172d167b8b48b

## Summary by Sourcery

Use a module-level logger in client and expand `_process_response_line` tests to cover code key detection and negative scenarios

Enhancements:
- Introduce module-level logger in client and replace direct logging calls

Tests:
- Add test for detecting dependency error via `code` key
- Add negative test for non-dependency error codes
- Add negative tests for non-error and malformed payloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning message logging for JSON decode errors to use a module-specific logger.

* **Tests**
  * Added unit tests to verify error detection for various JSON payload formats and error code key names in response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->