### PR TITLE
Improve RPC handler checks and diagnostics filtering

### DIFF
--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -167,6 +167,46 @@ async def handle_onboard_project() -> OnboardingReport:
     return OnboardingReport(details=details)
 
 
+def _normalize_filters(
+    severity: str | None, files: list[str] | None
+) -> tuple[str | None, set[str] | None]:
+    """Return case- and path-insensitive versions of filters."""
+
+    norm_severity = severity.lower() if severity else None
+    norm_files = (
+        {os.path.normcase(os.path.normpath(f)).lower() for f in files}
+        if files
+        else None
+    )
+    return norm_severity, norm_files
+
+
+def _normalize_diagnostic_data(diag: Diagnostic) -> tuple[str | None, str | None]:
+    """Return normalised severity and file path from ``diag``."""
+
+    diag_severity = diag.severity.lower() if diag.severity else None
+    diag_file = (
+        os.path.normcase(os.path.normpath(diag.location.file)).lower()
+        if diag.location and diag.location.file
+        else None
+    )
+    return diag_severity, diag_file
+
+
+def _should_include_diagnostic(
+    norm_severity: str | None,
+    norm_files: set[str] | None,
+    diag_severity: str | None,
+    diag_file: str | None,
+) -> bool:
+    """Return ``True`` if the diagnostic passes the given filters."""
+
+    return not (
+        (norm_severity and diag_severity != norm_severity)
+        or (norm_files and diag_file not in norm_files)
+    )
+
+
 @rpc_handler("list-diagnostics")
 async def handle_list_diagnostics(
     severity: str | None = None,
@@ -174,9 +214,8 @@ async def handle_list_diagnostics(
 ) -> typ.AsyncIterator[Diagnostic]:
     """Yield diagnostics, optionally filtered by severity and files."""
 
-    # Normalise filters to make comparisons case- and path-insensitive
-    norm_severity = severity.lower() if severity else None
-    norm_files = {os.path.normpath(f).lower() for f in files} if files else None
+    # Prepare filters for case- and path-insensitive comparison
+    norm_severity, norm_files = _normalize_filters(severity, files)
 
     tool = create_diagnostics_tool()
     try:
@@ -185,17 +224,11 @@ async def handle_list_diagnostics(
         raise RuntimeError(f"Diagnostics failed: {exc}") from exc
     for item in data:
         diag = ms.convert(item, Diagnostic)
-        diag_severity = diag.severity.lower() if diag.severity else None
-        diag_file = (
-            os.path.normpath(diag.location.file).lower()
-            if diag.location and diag.location.file
-            else None
-        )
-        if norm_severity and diag_severity != norm_severity:
-            continue
-        if norm_files and diag_file not in norm_files:
-            continue
-        yield diag
+        diag_severity, diag_file = _normalize_diagnostic_data(diag)
+        if _should_include_diagnostic(
+            norm_severity, norm_files, diag_severity, diag_file
+        ):
+            yield diag
 
 
 async def main(socket_path: Path | None = None) -> None:

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -39,6 +39,8 @@ def rpc_handler(name: str) -> typ.Callable[[Handler], Handler]:
     """Register ``func`` as an RPC handler with ``name``."""
 
     def decorator(func: Handler) -> Handler:
+        if any(existing == name for existing, _ in HANDLERS):
+            raise ValueError(f"handler '{name}' already registered")
         HANDLERS.append((name, func))
         return func
 
@@ -172,6 +174,10 @@ async def handle_list_diagnostics(
 ) -> typ.AsyncIterator[Diagnostic]:
     """Yield diagnostics, optionally filtered by severity and files."""
 
+    # Normalise filters to make comparisons case- and path-insensitive
+    norm_severity = severity.lower() if severity else None
+    norm_files = {os.path.normpath(f).lower() for f in files} if files else None
+
     tool = create_diagnostics_tool()
     try:
         data = await asyncio.to_thread(tool.list_diagnostics)
@@ -179,9 +185,15 @@ async def handle_list_diagnostics(
         raise RuntimeError(f"Diagnostics failed: {exc}") from exc
     for item in data:
         diag = ms.convert(item, Diagnostic)
-        if severity and diag.severity != severity:
+        diag_severity = diag.severity.lower() if diag.severity else None
+        diag_file = (
+            os.path.normpath(diag.location.file).lower()
+            if diag.location and diag.location.file
+            else None
+        )
+        if norm_severity and diag_severity != norm_severity:
             continue
-        if files and diag.location.file not in files:
+        if norm_files and diag_file not in norm_files:
             continue
         yield diag
 

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import typing as typ
 
 import msgspec.json as msjson
@@ -143,3 +144,26 @@ async def test_missing_diagnostics_dependency(
         await writer.wait_closed()
     srv.close()
     await srv.wait_closed()
+
+
+@pytest.mark.anyio
+async def test_list_diagnostics_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Tool:
+        def list_diagnostics(self) -> list[Diagnostic]:
+            loc = Location(
+                file="Foo.Py",
+                range=Range(start=Position(1, 0), end=Position(1, 1)),
+            )
+            return [
+                Diagnostic(location=loc, severity="Error", code="E1", message="boom")
+            ]
+
+    monkeypatch.setattr(server, "create_diagnostics_tool", lambda: Tool())
+
+    results = server.handle_list_diagnostics(severity="error", files=["foo.py"])
+    diag = await builtins.anext(results)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert diag.message == "boom"

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -21,7 +21,7 @@ async def _test_dispatcher_call(
     request_data: dict[str, typ.Any],
     expected_response: ProjectStatus,
 ) -> None:
-    """Helper to send an RPC request and assert the response."""
+    """Send ``request_data`` to ``dispatcher`` and check the result."""
     request = msjson.encode(request_data)
     results = dispatcher.handle(request)
     response = await builtins.anext(results)

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -16,6 +16,18 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
+async def _test_dispatcher_call(
+    dispatcher: RPCDispatcher,
+    request_data: dict[str, typ.Any],
+    expected_response: ProjectStatus,
+) -> None:
+    """Helper to send an RPC request and assert the response."""
+    request = msjson.encode(request_data)
+    results = dispatcher.handle(request)
+    response = await builtins.anext(results)
+    assert msjson.decode(response, type=ProjectStatus) == expected_response
+
+
 @pytest.mark.anyio
 async def test_dispatcher_handles_registered_method() -> None:
     dispatcher = RPCDispatcher()
@@ -24,11 +36,10 @@ async def test_dispatcher_handles_registered_method() -> None:
     async def handler() -> ProjectStatus:  # pyright: ignore[reportUnusedFunction]
         return ProjectStatus(pid=1, rss_mb=0.1, ready=True, message="ok")
 
-    request = msjson.encode({"method": "project-status"})
-    results = dispatcher.handle(request)
-    response = await builtins.anext(results)
-    assert msjson.decode(response, type=ProjectStatus) == ProjectStatus(
-        pid=1, rss_mb=0.1, ready=True, message="ok"
+    await _test_dispatcher_call(
+        dispatcher,
+        {"method": "project-status"},
+        ProjectStatus(pid=1, rss_mb=0.1, ready=True, message="ok"),
     )
 
 
@@ -42,11 +53,10 @@ async def test_dispatcher_passes_parameters() -> None:
             pid=value, rss_mb=float(value), ready=True, message=str(value)
         )
 
-    request = msjson.encode({"method": "echo", "params": {"value": 42}})
-    results = dispatcher.handle(request)
-    response = await builtins.anext(results)
-    assert msjson.decode(response, type=ProjectStatus) == ProjectStatus(
-        pid=42, rss_mb=42.0, ready=True, message="42"
+    await _test_dispatcher_call(
+        dispatcher,
+        {"method": "echo", "params": {"value": 42}},
+        ProjectStatus(pid=42, rss_mb=42.0, ready=True, message="42"),
     )
 
 

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -21,7 +21,7 @@ async def _test_dispatcher_call(
     request_data: dict[str, typ.Any],
     expected_response: ProjectStatus,
 ) -> None:
-    """Send ``request_data`` to ``dispatcher`` and check the result."""
+    """Send ``request_data`` to ``dispatcher`` and assert the result."""
     request = msjson.encode(request_data)
     results = dispatcher.handle(request)
     response = await builtins.anext(results)

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import typing as typ
 
 import msgspec.json as msjson
 import pytest
@@ -68,3 +69,42 @@ async def test_dispatcher_returns_error_on_bad_json() -> None:
     results = dispatcher.handle(b"not-json")
     err = msjson.decode(await builtins.anext(results), type=SchemaError)
     assert err.type == "error" and "invalid request" in err.message
+
+
+@pytest.mark.anyio
+async def test_dispatcher_streams_multiple_results() -> None:
+    dispatcher = RPCDispatcher()
+
+    @dispatcher.register("numbers")
+    async def numbers() -> typ.AsyncIterator[int]:  # pyright: ignore[reportUnusedFunction]
+        for i in range(3):
+            yield i
+
+    req = msjson.encode({"method": "numbers"})
+    results = dispatcher.handle(req)
+    output = [msjson.decode(await builtins.anext(results), type=int) for _ in range(3)]
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert output == [0, 1, 2]
+
+
+@pytest.mark.anyio
+async def test_dispatcher_streams_midstream_error() -> None:
+    dispatcher = RPCDispatcher()
+
+    async def boom() -> typ.AsyncIterator[int]:
+        yield 1
+        raise RuntimeError("boom")
+
+    @dispatcher.register("boom")
+    async def handler() -> typ.AsyncIterator[int]:  # pyright: ignore[reportUnusedFunction]
+        async for item in boom():
+            yield item
+
+    req = msjson.encode({"method": "boom"})
+    results = dispatcher.handle(req)
+    first = msjson.decode(await builtins.anext(results), type=int)
+    err = msjson.decode(await builtins.anext(results), type=SchemaError)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert first == 1 and err.message == "boom"

--- a/weaverd/unittests/test_server.py
+++ b/weaverd/unittests/test_server.py
@@ -71,3 +71,23 @@ async def test_server_handles_multiple_requests(tmp_path: Path) -> None:
         await writer.wait_closed()
     server.close()
     await server.wait_closed()
+
+
+def test_rpc_handler_rejects_duplicates() -> None:
+    from weaverd import server as srv
+
+    original = srv.HANDLERS.copy()
+    srv.HANDLERS.clear()
+    try:
+
+        @srv.rpc_handler("dup")
+        async def first() -> None:
+            pass
+
+        with pytest.raises(ValueError):
+
+            @srv.rpc_handler("dup")
+            async def second() -> None:  # pragma: no cover - stub
+                pass
+    finally:
+        srv.HANDLERS[:] = original


### PR DESCRIPTION
## Summary
- reject duplicate rpc_handler registrations
- normalize diagnostics filter criteria
- test RPC multi-chunk streams and mid-stream errors
- test rpc_handler duplicate detection
- test case-insensitive diagnostics filtering

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688a8e7a3c648322a76436dff6cbac9f

## Summary by Sourcery

Prevent duplicate RPC handler registrations, normalize diagnostics filtering criteria to be case- and path-insensitive, and add tests for RPC streaming behavior, midstream errors, duplicate detection, and diagnostics filtering.

Bug Fixes:
- Reject duplicate RPC handler registrations.

Enhancements:
- Normalize diagnostics filter criteria for case- and path-insensitive matching.

Tests:
- Add test for streaming multiple RPC results.
- Add test for handling mid-stream RPC errors.
- Add test for rejecting duplicate RPC handler registrations.
- Add test for case-insensitive diagnostics filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of diagnostics to be case- and path-insensitive, ensuring consistent results regardless of input format.
  * Prevented duplicate RPC handler registration by raising an error on duplicates.

* **Tests**
  * Added tests to verify diagnostics filtering works correctly with different file name and severity casings.
  * Introduced tests for RPC handler registration to prevent duplicate handlers.
  * Expanded RPC dispatcher tests to cover streaming multiple results and error handling during streaming.
  * Refactored test code to reduce duplication and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->