### PR TITLE
Fix CI secrets expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -57,20 +59,18 @@ jobs:
           path: coverage.xml
 
       - name: Install CodeScene Coverage CLI
-        if: ${{ secrets.CS_ACCESS_TOKEN != '' }}
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
         env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
           CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
         run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+          curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
           if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
+            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c - || exit 1
           fi
+          bash install-cs-coverage-tool.sh -y
 
       - name: Upload coverage to CodeScene
-        if: ${{ secrets.CS_ACCESS_TOKEN != '' }}
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
         run: |
           if [ ! -f coverage.xml ]; then
             echo "coverage.xml not found!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -60,7 +57,10 @@ jobs:
           path: coverage.xml
 
       - name: Install CodeScene Coverage CLI
-        if: env.CS_ACCESS_TOKEN != ''
+        if: ${{ secrets.CS_ACCESS_TOKEN != '' }}
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+          CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
         run: |
           curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
           if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
@@ -68,7 +68,9 @@ jobs:
           fi
 
       - name: Upload coverage to CodeScene
-        if: env.CS_ACCESS_TOKEN != ''
+        if: ${{ secrets.CS_ACCESS_TOKEN != '' }}
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         run: |
           if [ ! -f coverage.xml ]; then
             echo "coverage.xml not found!"


### PR DESCRIPTION
## Summary
- handle secrets at step level in `ci.yml`

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a93f268c88322abdbfeeb00ff31da

## Summary by Sourcery

Apply secrets at the step level in the GitHub Actions CI workflow and correct conditional checks for CodeScene steps

CI:
- Move CS_ACCESS_TOKEN and CODESCENE_CLI_SHA256 environment variables from the job level to individual steps
- Update if expressions to use the secrets context (using ${{ secrets.CS_ACCESS_TOKEN != '' }}) for CodeScene installation and upload steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to set environment variables locally within steps instead of globally.
  * Improved conditional checks for secrets in workflow steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->