### PR TITLE
Ensure RPC dispatcher imports typing and inspect

### DIFF
--- a/weaverd/rpc.py
+++ b/weaverd/rpc.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+# Inspect awaits handler results to support both sync and async handlers.
 import inspect
+
+# Use a short alias to keep type hints concise.
 import typing as typ
 
 import msgspec as ms


### PR DESCRIPTION
## Summary
- comment and import `inspect` for awaitable detection
- alias `typing` as `typ` for concise type hints

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688dcf18af2c8322919f8c10148e3c0e

## Summary by Sourcery

Import inspect and alias typing as typ in the RPC dispatcher to support awaitable detection and streamline type hints.

Enhancements:
- Import inspect for awaitable detection in RPC dispatcher
- Alias typing as typ for concise type hints in RPC dispatcher