### PR TITLE
Refactor CLI RPC calls

### DIFF
--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -42,14 +42,21 @@ def _make_stub(name: str) -> typ.Callable[[], None]:
     return command
 
 
+def _run_rpc(method: str, params: dict | None = None) -> None:
+    """Execute an RPC request and handle failures uniformly."""
+    try:
+        anyio.run(rpc_call, method, params)
+    except Exception as exc:
+        # We surface the raw error to aid debugging while keeping exit codes
+        # consistent for callers that rely on them.
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+
 @app.command("project-status")
 def project_status() -> None:
     """Check daemon and language server health."""
-    try:
-        anyio.run(rpc_call, "project-status")
-    except Exception as exc:
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(1) from exc
+    _run_rpc("project-status")
 
 
 @app.command("list-diagnostics")
@@ -68,21 +75,13 @@ def list_diagnostics(
         params["severity"] = severity
     if files:
         params["files"] = [str(p) for p in files]
-    try:
-        anyio.run(rpc_call, "list-diagnostics", params or None)
-    except Exception as exc:
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(1) from exc
+    _run_rpc("list-diagnostics", params or None)
 
 
 @app.command("onboard-project")
 def onboard_project() -> None:
     """Perform first-run project analysis."""
-    try:
-        anyio.run(rpc_call, "onboard-project")
-    except Exception as exc:
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(1) from exc
+    _run_rpc("onboard-project")
 
 
 STUBS = [

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -1,13 +1,15 @@
 import pathlib
 
+import pytest
+import typer
 from typer.testing import CliRunner
 
-from weaver.cli import app
+import weaver.cli as cli
 
 
 def test_cli_hello() -> None:
     runner = CliRunner()
-    result = runner.invoke(app, ["hello"])
+    result = runner.invoke(cli.app, ["hello"])
     assert result.exit_code == 0
     assert "hello from Python" in result.stdout
 
@@ -15,6 +17,61 @@ def test_cli_hello() -> None:
 def test_cli_check_socket(tmp_path: pathlib.Path) -> None:
     runner = CliRunner()
     sock_path = tmp_path / "nope"
-    result = runner.invoke(app, ["check-socket", str(sock_path)])
+    result = runner.invoke(cli.app, ["check-socket", str(sock_path)])
     assert result.exit_code == 0
     assert f"socket unavailable: {sock_path}" in result.stdout
+
+
+def test_run_rpc_invokes_anyio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure _run_rpc delegates to anyio.run without I/O."""
+    called: dict[str, object] = {}
+
+    def fake_run(func, method, params=None):
+        # The helper should forward rpc_call and user arguments verbatim.
+        called.update({"func": func, "method": method, "params": params})
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    cli._run_rpc("test-method", {"a": 1})
+
+    assert called == {
+        "func": cli.rpc_call,
+        "method": "test-method",
+        "params": {"a": 1},
+    }
+
+
+def test_run_rpc_reports_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """_run_rpc should convert exceptions into user-friendly exits."""
+
+    def fake_run(func, method, params=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    with pytest.raises(typer.Exit):
+        cli._run_rpc("broken")
+
+    assert "Error: boom" in capsys.readouterr().err
+
+
+def test_cli_project_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """project-status uses _run_rpc to contact the daemon."""
+    called: dict[str, object] = {}
+
+    def fake_run(func, method, params=None):
+        # Avoid network access while verifying parameters.
+        called.update({"func": func, "method": method, "params": params})
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["project-status"])
+
+    assert result.exit_code == 0
+    assert called == {
+        "func": cli.rpc_call,
+        "method": "project-status",
+        "params": None,
+    }

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -56,8 +56,17 @@ def test_run_rpc_reports_error(
     assert "Error: boom" in capsys.readouterr().err
 
 
-def test_cli_project_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    """project-status uses _run_rpc to contact the daemon."""
+@pytest.mark.parametrize(
+    ("cli_command", "rpc_method"),
+    [
+        ("project-status", "project-status"),
+        ("onboard-project", "onboard-project"),
+    ],
+)
+def test_cli_commands_use_run_rpc(
+    cli_command: str, rpc_method: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI commands use _run_rpc to contact the daemon."""
     called: dict[str, object] = {}
 
     def fake_run(func, method, params=None):
@@ -67,33 +76,12 @@ def test_cli_project_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli.anyio, "run", fake_run)
 
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["project-status"])
+    result = runner.invoke(cli.app, [cli_command])
 
     assert result.exit_code == 0
     assert called == {
         "func": cli.rpc_call,
-        "method": "project-status",
-        "params": None,
-    }
-
-
-def test_cli_onboard_project(monkeypatch: pytest.MonkeyPatch) -> None:
-    """onboard-project uses _run_rpc to contact the daemon."""
-    called: dict[str, object] = {}
-
-    def fake_run(func, method, params=None):
-        # Avoid network access while verifying parameters.
-        called.update({"func": func, "method": method, "params": params})
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
-
-    runner = CliRunner()
-    result = runner.invoke(cli.app, ["onboard-project"])
-
-    assert result.exit_code == 0
-    assert called == {
-        "func": cli.rpc_call,
-        "method": "onboard-project",
+        "method": rpc_method,
         "params": None,
     }
 

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -75,3 +75,41 @@ def test_cli_project_status(monkeypatch: pytest.MonkeyPatch) -> None:
         "method": "project-status",
         "params": None,
     }
+
+
+def test_cli_onboard_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    """onboard-project uses _run_rpc to contact the daemon."""
+    called: dict[str, object] = {}
+
+    def fake_run(func, method, params=None):
+        # Avoid network access while verifying parameters.
+        called.update({"func": func, "method": method, "params": params})
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["onboard-project"])
+
+    assert result.exit_code == 0
+    assert called == {
+        "func": cli.rpc_call,
+        "method": "onboard-project",
+        "params": None,
+    }
+
+
+def test_cli_onboard_project_reports_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """onboard-project surfaces RPC errors."""
+
+    def fake_run(func, method, params=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["onboard-project"])
+
+    assert result.exit_code == 1
+    assert "Error: boom" in result.stderr


### PR DESCRIPTION
## Summary
- centralize RPC invocation with `_run_rpc` helper and use it for project-status, list-diagnostics, and onboard-project commands
- add unit tests for `_run_rpc` and a CLI test for `project-status`

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688dcf27e1b48322af9cbc9407f6103b

## Summary by Sourcery

Centralize CLI RPC invocation with a shared helper, refactor commands to use it, and enhance error handling uniformly.

Enhancements:
- Introduce a `_run_rpc` helper to wrap anyio.run calls and handle exceptions consistently
- Refactor `project-status`, `list-diagnostics`, and `onboard-project` commands to use `_run_rpc` instead of duplicating the anyio.run logic

Tests:
- Add unit tests for `_run_rpc` to verify delegation to anyio.run and error reporting
- Add a CLI test for `project-status` to confirm it invokes `_run_rpc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling and RPC execution across CLI commands for a more consistent user experience.

* **Tests**
  * Added and updated tests to ensure correct CLI command behavior and improved error handling in RPC-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->