### PR TITLE
Refactor Serena tool creation

### DIFF
--- a/features/list_diagnostics.feature
+++ b/features/list_diagnostics.feature
@@ -16,6 +16,12 @@ Feature: list diagnostics command
     When I invoke the list-diagnostics command
     Then the daemon is not ready
 
+  Scenario: unknown tool attribute
+    Given a temporary runtime dir
+    And the tool attribute is unknown
+    When I invoke the list-diagnostics command
+    Then the tool attribute is reported missing
+
   Scenario: malformed output
     Given a temporary runtime dir
     And the server returns malformed output

--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -32,7 +32,7 @@ def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Contex
                 )
             ]
 
-    monkeypatch.setattr(server, "create_diagnostics_tool", lambda: StubTool())
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
 
     def setup(dispatcher: RPCDispatcher) -> None:
         @dispatcher.register("list-diagnostics")
@@ -40,7 +40,7 @@ def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Contex
             severity: str | None = None,
             files: list[str] | None = None,
         ) -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-            tool = server.create_diagnostics_tool()
+            tool = server.create_serena_tool("ListDiagnosticsTool")
             for d in tool.list_diagnostics():
                 if severity and d.severity != severity:
                     continue
@@ -59,10 +59,10 @@ def daemon_running(context: Context) -> None:
 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error() -> None:
+    def raise_error(_: str) -> None:
         raise RuntimeError("serena-agent not found")
 
-    monkeypatch.setattr(server, "create_diagnostics_tool", raise_error)
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
 
 @given("the server returns malformed output")

--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -65,6 +65,14 @@ def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
 
+@given("the tool attribute is unknown")
+def unknown_tool(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_error(_: str) -> None:
+        raise RuntimeError("NoSuchTool not found in serena")
+
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+
+
 @given("the server returns malformed output")
 def server_malformed(context: Context) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
@@ -110,6 +118,14 @@ def check_not_ready(context: Context) -> None:
     assert result.exit_code == 1
     out = (result.stdout + result.stderr).lower()
     assert "serena" in out or "missing" in out
+
+
+@then("the tool attribute is reported missing")
+def check_unknown_tool(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 0
+    out = (result.stdout + result.stderr).lower()
+    assert "not found" in out or "unknown" in out
 
 
 @then("the output is malformed")

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -10,7 +10,7 @@ from features.types import Context
 from weaver.cli import app
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
-from weaverd.server import create_onboarding_tool
+from weaverd.serena_tools import create_serena_tool
 
 scenarios("../onboard_project.feature")
 
@@ -22,7 +22,7 @@ def runtime_dir(runtime_dir: Context) -> Context:
         async def onboard() -> OnboardingReport:  # pragma: no cover - stub
             if os.environ.get("WEAVER_TEST_MISSING_SERENA"):
                 raise RuntimeError("serena-agent not found")
-            tool = create_onboarding_tool()
+            tool = create_serena_tool("OnboardingTool")
             return OnboardingReport(details=tool.apply())
 
     runtime_dir["register"](setup)

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utilities for creating Serena tools used by the daemon."""
+
+from importlib import import_module  # noqa: E402 - import below module docstring
+
+# pyright: reportMissingImports=false  # Serena optional dependency
+
+
+class _BareAgent:
+    """Minimal agent providing only the prompt factory."""
+
+    def __init__(self, prompt_factory) -> None:
+        self.prompt_factory = prompt_factory
+
+
+def _load_serena_tool(tool_attr: str):
+    """Return the requested Serena tool class and prompt factory.
+
+    Raises:
+        RuntimeError: if the ``serena-agent`` package is missing or the tool
+        attribute cannot be imported.
+    """
+    try:
+        wf_tools = import_module("serena.tools.workflow_tools")
+        prompt_mod = import_module("serena.prompt_factory")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+        msg = "serena-agent is required; install it via 'uv add serena-agent'."
+        raise RuntimeError(msg) from exc
+
+    tool_cls = getattr(wf_tools, tool_attr, None)
+    if tool_cls is None:  # pragma: no cover - optional dep
+        raise RuntimeError(f"{tool_attr} not found in serena")
+
+    return tool_cls, prompt_mod.SerenaPromptFactory
+
+
+def create_serena_tool(tool_attr: str):
+    """Instantiate a Serena tool given its attribute name."""
+
+    tool_cls, prompt_factory = _load_serena_tool(tool_attr)
+    return tool_cls(_BareAgent(prompt_factory()))

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -1,8 +1,9 @@
-from __future__ import annotations
-
 """Utilities for creating Serena tools used by the daemon."""
 
-from importlib import import_module  # noqa: E402 - import below module docstring
+from __future__ import annotations
+
+import typing as typ
+from importlib import import_module
 
 # pyright: reportMissingImports=false  # Serena optional dependency
 
@@ -10,11 +11,11 @@ from importlib import import_module  # noqa: E402 - import below module docstrin
 class _BareAgent:
     """Minimal agent providing only the prompt factory."""
 
-    def __init__(self, prompt_factory) -> None:
+    def __init__(self, prompt_factory: typ.Any) -> None:
         self.prompt_factory = prompt_factory
 
 
-def _load_serena_tool(tool_attr: str):
+def _load_serena_tool(tool_attr: str) -> tuple[typ.Any, typ.Any]:
     """Return the requested Serena tool class and prompt factory.
 
     Raises:
@@ -35,7 +36,7 @@ def _load_serena_tool(tool_attr: str):
     return tool_cls, prompt_mod.SerenaPromptFactory
 
 
-def create_serena_tool(tool_attr: str):
+def create_serena_tool(tool_attr: str) -> typ.Any:
     """Instantiate a Serena tool given its attribute name."""
 
     tool_cls, prompt_factory = _load_serena_tool(tool_attr)

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -21,15 +21,9 @@ from weaver_schemas.reports import OnboardingReport
 from weaver_schemas.status import ProjectStatus
 
 from .rpc import Handler, RPCDispatcher
+from .serena_tools import create_serena_tool
 
 logger = logging.getLogger(__name__)
-
-
-class _BareAgent:
-    """Minimal agent providing only the prompt factory."""
-
-    def __init__(self, prompt_factory) -> None:
-        self.prompt_factory = prompt_factory
 
 
 HANDLERS: list[tuple[str, Handler]] = []
@@ -45,41 +39,6 @@ def rpc_handler(name: str) -> typ.Callable[[Handler], Handler]:
         return func
 
     return decorator
-
-
-def _load_serena_tool(tool_attr: str):
-    """Return the requested Serena tool and prompt factory.
-
-    Raises:
-        RuntimeError: if the ``serena-agent`` package is missing or the tool
-            attribute cannot be imported.
-    """
-    try:
-        wf_tools = import_module("serena.tools.workflow_tools")
-        prompt_mod = import_module("serena.prompt_factory")
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        msg = "serena-agent is required; install it via 'uv add serena-agent'."
-        raise RuntimeError(msg) from exc
-
-    tool_cls = getattr(wf_tools, tool_attr, None)
-    if tool_cls is None:  # pragma: no cover - optional dep
-        raise RuntimeError(f"{tool_attr} not found in serena")
-
-    return tool_cls, prompt_mod.SerenaPromptFactory
-
-
-def create_onboarding_tool():
-    """Return an instance of Serena's onboarding tool."""
-
-    tool_cls, prompt_factory = _load_serena_tool("OnboardingTool")
-    return tool_cls(_BareAgent(prompt_factory()))
-
-
-def create_diagnostics_tool():
-    """Return an instance of Serena's diagnostics tool."""
-
-    tool_cls, prompt_factory = _load_serena_tool("ListDiagnosticsTool")
-    return tool_cls(_BareAgent(prompt_factory()))
 
 
 def default_socket_path() -> Path:
@@ -158,8 +117,7 @@ async def handle_project_status() -> ProjectStatus:
 @rpc_handler("onboard-project")
 async def handle_onboard_project() -> OnboardingReport:
     """Run the onboarding tool and return its report."""
-
-    tool = create_onboarding_tool()
+    tool = create_serena_tool("OnboardingTool")
     try:
         details = await asyncio.to_thread(tool.apply)
     except Exception as exc:  # pragma: no cover - unexpected failures
@@ -217,7 +175,7 @@ async def handle_list_diagnostics(
     # Prepare filters for case- and path-insensitive comparison
     norm_severity, norm_files = _normalize_filters(severity, files)
 
-    tool = create_diagnostics_tool()
+    tool = create_serena_tool("ListDiagnosticsTool")
     try:
         data = await asyncio.to_thread(tool.list_diagnostics)
     except RuntimeError as exc:

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -37,14 +37,14 @@ async def test_list_diagnostics(
 ) -> None:
     dispatcher = RPCDispatcher()
 
-    monkeypatch.setattr(server, "create_diagnostics_tool", lambda: StubTool())
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
 
     @dispatcher.register("list-diagnostics")
     async def handler(
         severity: str | None = None,
         files: list[str] | None = None,
     ) -> typ.AsyncIterator[Diagnostic]:
-        tool = server.create_diagnostics_tool()
+        tool = server.create_serena_tool("ListDiagnosticsTool")
         for d in tool.list_diagnostics():
             if severity and d.severity != severity:
                 continue
@@ -74,14 +74,14 @@ async def test_list_diagnostics_filtered(
 ) -> None:
     dispatcher = RPCDispatcher()
 
-    monkeypatch.setattr(server, "create_diagnostics_tool", lambda: StubTool())
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
 
     @dispatcher.register("list-diagnostics")
     async def handler(
         severity: str | None = None,
         files: list[str] | None = None,
     ) -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-        tool = server.create_diagnostics_tool()
+        tool = server.create_serena_tool("ListDiagnosticsTool")
         for d in tool.list_diagnostics():
             if severity and d.severity != severity:
                 continue
@@ -118,14 +118,14 @@ async def test_missing_diagnostics_dependency(
 ) -> None:
     dispatcher = RPCDispatcher()
 
-    def raise_error() -> StubTool:
+    def raise_error(_: str) -> StubTool:
         raise RuntimeError("serena-agent not found")
 
-    monkeypatch.setattr(server, "create_diagnostics_tool", raise_error)
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
     @dispatcher.register("list-diagnostics")
     async def handler() -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-        tool = server.create_diagnostics_tool()
+        tool = server.create_serena_tool("ListDiagnosticsTool")
         for d in tool.list_diagnostics():
             yield d
 
@@ -160,7 +160,7 @@ async def test_list_diagnostics_case_insensitive(
                 Diagnostic(location=loc, severity="Error", code="E1", message="boom")
             ]
 
-    monkeypatch.setattr(server, "create_diagnostics_tool", lambda: Tool())
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: Tool())
 
     results = server.handle_list_diagnostics(severity="error", files=["foo.py"])
     diag = await builtins.anext(results)

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -31,12 +31,18 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-@pytest.mark.anyio
-async def test_list_diagnostics(
+@pytest.fixture()
+async def diagnostics_test_server(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    dispatcher = RPCDispatcher()
+) -> typ.AsyncIterator[Path]:
+    """Start a diagnostics test server and yield its socket path.
 
+    The server uses a stub Serena tool and exposes the ``list-diagnostics``
+    handler with filtering by severity and file. Consumers should close any
+    client connections they create; this fixture handles the server lifecycle.
+    """
+
+    dispatcher = RPCDispatcher()
     monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
 
     @dispatcher.register("list-diagnostics")
@@ -45,27 +51,35 @@ async def test_list_diagnostics(
         files: list[str] | None = None,
     ) -> typ.AsyncIterator[Diagnostic]:
         tool = server.create_serena_tool("ListDiagnosticsTool")
-        for d in tool.list_diagnostics():
-            if severity and d.severity != severity:
+        for diag in tool.list_diagnostics():
+            if severity and diag.severity != severity:
                 continue
-            if files and d.location.file not in files:
+            if files and diag.location.file not in files:
                 continue
-            yield d
+            yield diag
 
     sock = tmp_path / "d.sock"
     srv = await start_server(sock, dispatcher)
-    async with srv:
-        reader, writer = await asyncio.open_unix_connection(str(sock))
-        writer.write(msjson.encode({"method": "list-diagnostics"}) + b"\n")
-        await writer.drain()
-        writer.write_eof()
-        data = await reader.readline()
-        diag = msjson.decode(data.rstrip(), type=Diagnostic)
-        assert diag.message == "boom"
-        writer.close()
-        await writer.wait_closed()
-    srv.close()
-    await srv.wait_closed()
+    try:
+        async with srv:
+            yield sock
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.anyio
+async def test_list_diagnostics(diagnostics_test_server: Path) -> None:
+    sock = diagnostics_test_server
+    reader, writer = await asyncio.open_unix_connection(str(sock))
+    writer.write(msjson.encode({"method": "list-diagnostics"}) + b"\n")
+    await writer.drain()
+    writer.write_eof()
+    data = await reader.readline()
+    diag = msjson.decode(data.rstrip(), type=Diagnostic)
+    assert diag.message == "boom"
+    writer.close()
+    await writer.wait_closed()
 
 
 def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,47 +109,24 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.anyio
-async def test_list_diagnostics_filtered(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    dispatcher = RPCDispatcher()
-
-    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
-
-    @dispatcher.register("list-diagnostics")
-    async def handler(
-        severity: str | None = None,
-        files: list[str] | None = None,
-    ) -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-        tool = server.create_serena_tool("ListDiagnosticsTool")
-        for d in tool.list_diagnostics():
-            if severity and d.severity != severity:
-                continue
-            if files and d.location.file not in files:
-                continue
-            yield d
-
-    sock = tmp_path / "f.sock"
-    srv = await start_server(sock, dispatcher)
-    async with srv:
-        reader, writer = await asyncio.open_unix_connection(str(sock))
-        writer.write(
-            msjson.encode(
-                {
-                    "method": "list-diagnostics",
-                    "params": {"severity": "Warning", "files": ["foo.py"]},
-                }
-            )
-            + b"\n"
+async def test_list_diagnostics_filtered(diagnostics_test_server: Path) -> None:
+    sock = diagnostics_test_server
+    reader, writer = await asyncio.open_unix_connection(str(sock))
+    writer.write(
+        msjson.encode(
+            {
+                "method": "list-diagnostics",
+                "params": {"severity": "Warning", "files": ["foo.py"]},
+            }
         )
-        await writer.drain()
-        writer.write_eof()
-        data = await reader.readline()
-        assert data == b""  # no results
-        writer.close()
-        await writer.wait_closed()
-    srv.close()
-    await srv.wait_closed()
+        + b"\n",
+    )
+    await writer.drain()
+    writer.write_eof()
+    data = await reader.readline()
+    assert data == b""  # no results
+    writer.close()
+    await writer.wait_closed()
 
 
 @pytest.mark.anyio

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -68,6 +68,32 @@ async def test_list_diagnostics(
     await srv.wait_closed()
 
 
+def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """create_serena_tool should error for unknown tool attributes."""
+
+    from weaverd import serena_tools
+
+    class ToolsMod:  # pragma: no cover - simple stub
+        pass
+
+    class PromptMod:  # pragma: no cover - simple stub
+        class SerenaPromptFactory:  # pragma: no cover - simple stub
+            def __call__(self) -> None:  # pragma: no cover - simple stub
+                return None
+
+    def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
+        if name == "serena.tools.workflow_tools":
+            return ToolsMod()
+        if name == "serena.prompt_factory":
+            return PromptMod
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(serena_tools, "import_module", fake_import)
+
+    with pytest.raises(RuntimeError, match="NoSuchTool"):
+        serena_tools.create_serena_tool("NoSuchTool")
+
+
 @pytest.mark.anyio
 async def test_list_diagnostics_filtered(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -11,7 +11,8 @@ import pytest
 
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
-from weaverd.server import create_onboarding_tool, start_server
+from weaverd.serena_tools import create_serena_tool
+from weaverd.server import start_server
 
 
 @pytest.fixture()
@@ -25,7 +26,7 @@ async def test_onboard_project(tmp_path: Path) -> None:
 
     @dispatcher.register("onboard-project")
     async def onboard() -> OnboardingReport:  # pyright: ignore[reportUnusedFunction]
-        tool = create_onboarding_tool()
+        tool = create_serena_tool("OnboardingTool")
         return OnboardingReport(details=tool.apply())
 
     sock = tmp_path / "o.sock"


### PR DESCRIPTION
## Summary
- extract generic `create_serena_tool` helper for Serena tool instantiation
- replace onboarding and diagnostics helpers with calls to the generic factory
- update server and tests to use the new helper

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893db38d47c8322a0973a166084b3fb

## Summary by Sourcery

Extract generic Serena tool factory and refactor server and tests to use it

New Features:
- Add create_serena_tool helper to instantiate Serena tools dynamically
- Introduce diagnostics_test_server pytest fixture for streamlined test server setup

Enhancements:
- Move Serena tool loading logic into new weaverd/serena_tools module
- Refactor server handlers to use generic create_serena_tool and remove specialized helpers

Tests:
- Update unit and BDD tests to use create_serena_tool and diagnostics_test_server fixture
- Add test for error when requesting an unknown Serena tool attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified tool creation utility for Serena tools, enabling instantiation by tool name with enhanced error handling.
  * Added support for detecting and reporting unknown tool attributes in diagnostics commands and related tests.

* **Refactor**
  * Centralized tool creation logic by replacing multiple factory functions with a single interface.
  * Updated application and test code to adopt the new tool creation method for improved consistency.

* **Tests**
  * Added new scenarios and tests covering unknown tool attributes.
  * Refined test suites to integrate the updated tool creation approach, ensuring robust coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->