### PR TITLE
Introduce Serena tool enum with caching

### DIFF
--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -12,6 +12,7 @@ from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.primitives import Location, Position, Range
 from weaverd import server
 from weaverd.rpc import RPCDispatcher
+from weaverd.serena_tools import SerenaTool
 
 scenarios("../list_diagnostics.feature")
 
@@ -40,7 +41,7 @@ def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Contex
             severity: str | None = None,
             files: list[str] | None = None,
         ) -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-            tool = server.create_serena_tool("ListDiagnosticsTool")
+            tool = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
             for d in tool.list_diagnostics():
                 if severity and d.severity != severity:
                     continue
@@ -59,7 +60,7 @@ def daemon_running(context: Context) -> None:
 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error(_: str) -> None:
+    def raise_error(_: SerenaTool) -> None:
         raise RuntimeError("serena-agent not found")
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
@@ -67,7 +68,7 @@ def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @given("the tool attribute is unknown")
 def unknown_tool(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error(_: str) -> None:
+    def raise_error(_: SerenaTool) -> None:
         raise RuntimeError("NoSuchTool not found in serena")
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -10,7 +10,7 @@ from features.types import Context
 from weaver.cli import app
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import create_serena_tool
+from weaverd.serena_tools import SerenaTool, create_serena_tool
 
 scenarios("../onboard_project.feature")
 
@@ -22,7 +22,7 @@ def runtime_dir(runtime_dir: Context) -> Context:
         async def onboard() -> OnboardingReport:  # pragma: no cover - stub
             if os.environ.get("WEAVER_TEST_MISSING_SERENA"):
                 raise RuntimeError("serena-agent not found")
-            tool = create_serena_tool("OnboardingTool")
+            tool = create_serena_tool(SerenaTool.ONBOARDING)
             return OnboardingReport(details=tool.apply())
 
     runtime_dir["register"](setup)

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -32,13 +32,35 @@ def _serena_modules() -> tuple[typ.Any, typ.Any]:
 
 
 def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
-    """Instantiate a Serena tool given its attribute name."""
+    """Instantiate a Serena tool.
+
+    Accepts:
+      - ``SerenaTool`` enum member, e.g. ``SerenaTool.ONBOARDING``
+      - ``str``: either the enum member name (``"ONBOARDING"``) or the
+        ``serena.tools.workflow_tools`` attribute name (``"OnboardingTool"``).
+
+    Raises:
+      ``RuntimeError`` if the tool class is not found or not callable.
+      ``TypeError`` if ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
+    """
 
     wf_tools, prompt_factory_cls = _serena_modules()
-    name = tool_attr.value if isinstance(tool_attr, SerenaTool) else tool_attr
+    if isinstance(tool_attr, SerenaTool):
+        name = tool_attr.value
+    elif isinstance(tool_attr, str):
+        try:
+            # Allow enum member names such as "ONBOARDING".
+            name = SerenaTool[tool_attr].value
+        except KeyError:
+            name = tool_attr
+    else:
+        raise TypeError("tool_attr must be SerenaTool or str")
+
     tool_cls = getattr(wf_tools, name, None)
     if tool_cls is None:  # pragma: no cover - optional dep
-        raise RuntimeError(f"{name} not found in serena")
+        raise RuntimeError(f"serena.tools.workflow_tools.{name} not found")
+    if not callable(tool_cls):  # pragma: no cover - defensive
+        raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
 
     agent = SimpleNamespace(prompt_factory=prompt_factory_cls())
     return tool_cls(agent)

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import dataclasses
 import enum
 import typing as typ
 from functools import cache
 from importlib import import_module
-from types import SimpleNamespace
 
 # pyright: reportMissingImports=false  # Serena optional dependency
 
+if typ.TYPE_CHECKING:  # pragma: no cover - import-time only
+    from types import ModuleType
 
-class SerenaTool(str, enum.Enum):
+    from serena.prompt_factory import SerenaPromptFactory
+else:  # pragma: no cover - import-time only
+
+    class SerenaPromptFactory(typ.Protocol):  # type: ignore[reportMissingTypeStubs]
+        """Typed placeholder used when Serena is not installed."""
+
+
+class SerenaTool(enum.StrEnum):
     """Supported Serena tools."""
 
     ONBOARDING = "OnboardingTool"
@@ -19,11 +28,15 @@ class SerenaTool(str, enum.Enum):
 
 
 @cache
-def _serena_modules() -> tuple[typ.Any, typ.Any]:
+def _serena_modules() -> tuple[ModuleType, type[SerenaPromptFactory]]:
     """Return workflow tools module and prompt factory."""
 
     try:
         wf_tools = import_module("serena.tools.workflow_tools")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+        msg = "serena-agent is required; install it via 'uv add serena-agent'."
+        raise RuntimeError(msg) from exc
+    try:
         prompt_mod = import_module("serena.prompt_factory")
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
         msg = "serena-agent is required; install it via 'uv add serena-agent'."
@@ -31,7 +44,35 @@ def _serena_modules() -> tuple[typ.Any, typ.Any]:
     return wf_tools, prompt_mod.SerenaPromptFactory
 
 
-def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
+class SerenaToolProtocol(typ.Protocol):
+    """Expected interface for Serena tools."""
+
+    def run(self, *args: object, **kwargs: object) -> object: ...
+    def __getattr__(self, name: str) -> typ.Any: ...
+
+
+def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
+    """Normalise tool identifiers to workflow attribute names."""
+
+    if isinstance(tool_attr, SerenaTool):
+        return tool_attr.value
+    if isinstance(tool_attr, str):
+        try:
+            # Allow enum member names such as "ONBOARDING".
+            return SerenaTool[tool_attr].value
+        except KeyError:
+            return tool_attr
+    raise TypeError("tool_attr must be SerenaTool or str")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Agent:
+    """Minimal agent providing only the prompt factory."""
+
+    prompt_factory: SerenaPromptFactory
+
+
+def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolProtocol:
     """Instantiate a Serena tool.
 
     Accepts:
@@ -45,16 +86,7 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
     """
 
     wf_tools, prompt_factory_cls = _serena_modules()
-    if isinstance(tool_attr, SerenaTool):
-        name = tool_attr.value
-    elif isinstance(tool_attr, str):
-        try:
-            # Allow enum member names such as "ONBOARDING".
-            name = SerenaTool[tool_attr].value
-        except KeyError:
-            name = tool_attr
-    else:
-        raise TypeError("tool_attr must be SerenaTool or str")
+    name = _resolve_tool_name(tool_attr)
 
     tool_cls = getattr(wf_tools, name, None)
     if tool_cls is None:  # pragma: no cover - optional dep
@@ -62,5 +94,5 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
     if not callable(tool_cls):  # pragma: no cover - defensive
         raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
 
-    agent = SimpleNamespace(prompt_factory=prompt_factory_cls())
-    return tool_cls(agent)
+    agent = _Agent(prompt_factory_cls())
+    return typ.cast("SerenaToolProtocol", tool_cls(agent))

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -2,42 +2,43 @@
 
 from __future__ import annotations
 
+import enum
 import typing as typ
+from functools import cache
 from importlib import import_module
+from types import SimpleNamespace
 
 # pyright: reportMissingImports=false  # Serena optional dependency
 
 
-class _BareAgent:
-    """Minimal agent providing only the prompt factory."""
+class SerenaTool(str, enum.Enum):
+    """Supported Serena tools."""
 
-    def __init__(self, prompt_factory: typ.Any) -> None:
-        self.prompt_factory = prompt_factory
+    ONBOARDING = "OnboardingTool"
+    LIST_DIAGNOSTICS = "ListDiagnosticsTool"
 
 
-def _load_serena_tool(tool_attr: str) -> tuple[typ.Any, typ.Any]:
-    """Return the requested Serena tool class and prompt factory.
+@cache
+def _serena_modules() -> tuple[typ.Any, typ.Any]:
+    """Return workflow tools module and prompt factory."""
 
-    Raises:
-        RuntimeError: if the ``serena-agent`` package is missing or the tool
-        attribute cannot be imported.
-    """
     try:
         wf_tools = import_module("serena.tools.workflow_tools")
         prompt_mod = import_module("serena.prompt_factory")
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
         msg = "serena-agent is required; install it via 'uv add serena-agent'."
         raise RuntimeError(msg) from exc
-
-    tool_cls = getattr(wf_tools, tool_attr, None)
-    if tool_cls is None:  # pragma: no cover - optional dep
-        raise RuntimeError(f"{tool_attr} not found in serena")
-
-    return tool_cls, prompt_mod.SerenaPromptFactory
+    return wf_tools, prompt_mod.SerenaPromptFactory
 
 
-def create_serena_tool(tool_attr: str) -> typ.Any:
+def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
     """Instantiate a Serena tool given its attribute name."""
 
-    tool_cls, prompt_factory = _load_serena_tool(tool_attr)
-    return tool_cls(_BareAgent(prompt_factory()))
+    wf_tools, prompt_factory_cls = _serena_modules()
+    name = tool_attr.value if isinstance(tool_attr, SerenaTool) else tool_attr
+    tool_cls = getattr(wf_tools, name, None)
+    if tool_cls is None:  # pragma: no cover - optional dep
+        raise RuntimeError(f"{name} not found in serena")
+
+    agent = SimpleNamespace(prompt_factory=prompt_factory_cls())
+    return tool_cls(agent)

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -21,7 +21,7 @@ from weaver_schemas.reports import OnboardingReport
 from weaver_schemas.status import ProjectStatus
 
 from .rpc import Handler, RPCDispatcher
-from .serena_tools import create_serena_tool
+from .serena_tools import SerenaTool, create_serena_tool
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ async def handle_project_status() -> ProjectStatus:
 @rpc_handler("onboard-project")
 async def handle_onboard_project() -> OnboardingReport:
     """Run the onboarding tool and return its report."""
-    tool = create_serena_tool("OnboardingTool")
+    tool = create_serena_tool(SerenaTool.ONBOARDING)
     try:
         details = await asyncio.to_thread(tool.apply)
     except Exception as exc:  # pragma: no cover - unexpected failures
@@ -175,7 +175,7 @@ async def handle_list_diagnostics(
     # Prepare filters for case- and path-insensitive comparison
     norm_severity, norm_files = _normalize_filters(severity, files)
 
-    tool = create_serena_tool("ListDiagnosticsTool")
+    tool = create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
     try:
         data = await asyncio.to_thread(tool.list_diagnostics)
     except RuntimeError as exc:

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -12,6 +12,7 @@ from weaver_schemas.error import SchemaError
 from weaver_schemas.primitives import Location, Position, Range
 from weaverd import server
 from weaverd.rpc import RPCDispatcher
+from weaverd.serena_tools import SerenaTool
 from weaverd.server import start_server
 
 if typ.TYPE_CHECKING:
@@ -50,7 +51,7 @@ async def diagnostics_test_server(
         severity: str | None = None,
         files: list[str] | None = None,
     ) -> typ.AsyncIterator[Diagnostic]:
-        tool = server.create_serena_tool("ListDiagnosticsTool")
+        tool = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
         for diag in tool.list_diagnostics():
             if severity and diag.severity != severity:
                 continue
@@ -103,9 +104,11 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
         raise ModuleNotFoundError
 
     monkeypatch.setattr(serena_tools, "import_module", fake_import)
+    serena_tools._serena_modules.cache_clear()
 
     with pytest.raises(RuntimeError, match="NoSuchTool"):
         serena_tools.create_serena_tool("NoSuchTool")
+    serena_tools._serena_modules.cache_clear()
 
 
 @pytest.mark.anyio
@@ -135,14 +138,14 @@ async def test_missing_diagnostics_dependency(
 ) -> None:
     dispatcher = RPCDispatcher()
 
-    def raise_error(_: str) -> StubTool:
+    def raise_error(_: SerenaTool) -> StubTool:
         raise RuntimeError("serena-agent not found")
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
     @dispatcher.register("list-diagnostics")
     async def handler() -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-        tool = server.create_serena_tool("ListDiagnosticsTool")
+        tool = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
         for d in tool.list_diagnostics():
             yield d
 

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -106,8 +106,8 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(serena_tools, "import_module", fake_import)
     serena_tools._serena_modules.cache_clear()
 
-    with pytest.raises(RuntimeError, match="NoSuchTool"):
-        serena_tools.create_serena_tool("NoSuchTool")
+    with pytest.raises(RuntimeError, match="workflow_tools.OnboardingTool"):
+        serena_tools.create_serena_tool(SerenaTool.ONBOARDING)
     serena_tools._serena_modules.cache_clear()
 
 

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -11,7 +11,7 @@ import pytest
 
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import create_serena_tool
+from weaverd.serena_tools import SerenaTool, create_serena_tool
 from weaverd.server import start_server
 
 
@@ -26,7 +26,7 @@ async def test_onboard_project(tmp_path: Path) -> None:
 
     @dispatcher.register("onboard-project")
     async def onboard() -> OnboardingReport:  # pyright: ignore[reportUnusedFunction]
-        tool = create_serena_tool("OnboardingTool")
+        tool = create_serena_tool(SerenaTool.ONBOARDING)
         return OnboardingReport(details=tool.apply())
 
     sock = tmp_path / "o.sock"


### PR DESCRIPTION
## Summary
- add SerenaTool enum and cache module imports for `create_serena_tool`
- use enum constants in server handlers
- clear Serena cache in diagnostics test to avoid cross-test interference

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895034e959c83228871b1fcf132a29f

## Summary by Sourcery

Introduce SerenaTool enum and caching for module imports in create_serena_tool, normalize tool resolution, and update server handlers and tests to use the new enum.

New Features:
- Add SerenaTool enum for supported tool identifiers
- Allow create_serena_tool to accept SerenaTool enum members

Enhancements:
- Cache serena tools module and prompt factory imports using functools.cache
- Introduce _resolve_tool_name helper to normalize enum and string identifiers
- Define SerenaToolProtocol interface and a dataclasses-based agent for tool instantiation

Tests:
- Update tests and server handlers to use SerenaTool enum instead of raw strings
- Clear _serena_modules cache in diagnostics tests to prevent cross-test interference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated tool selection throughout the application to use a new typed enum for tool identifiers instead of string literals, improving internal consistency and type safety.

* **Tests**
  * Adjusted test cases to use the new enum-based tool identifiers.
  * Enhanced test reliability by managing module caches during monkeypatching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->