### PR TITLE
Simplify Serena tool creation

### DIFF
--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -164,3 +164,6 @@ def test_create_serena_tool_string_enum_equivalence(
     serena_tools.clear_serena_imports()
     tool_str = server.create_serena_tool("LIST_DIAGNOSTICS")
     assert type(tool_enum) is type(tool_str)
+    serena_tools.clear_serena_imports()
+    tool_attr = server.create_serena_tool("ListDiagnosticsTool")
+    assert type(tool_enum) is type(tool_attr)

--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -10,7 +10,7 @@ from weaver import client
 from weaver.cli import app
 from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.primitives import Location, Position, Range
-from weaverd import server
+from weaverd import serena_tools, server
 from weaverd.rpc import RPCDispatcher
 from weaverd.serena_tools import SerenaTool
 
@@ -134,3 +134,33 @@ def check_malformed(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
     assert "malformed output" in result.stdout.lower()
+
+
+def test_create_serena_tool_string_enum_equivalence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_serena_tool accepts both enum and string names."""
+
+    class ToolsMod:  # pragma: no cover - simple stub
+        class ListDiagnosticsTool:  # pragma: no cover - simple stub
+            def __init__(self, _: typ.Any) -> None:  # pragma: no cover - stub
+                pass
+
+    class PromptMod:  # pragma: no cover - simple stub
+        class SerenaPromptFactory:  # pragma: no cover - simple stub
+            def __call__(self) -> None:  # pragma: no cover - stub
+                return None
+
+    def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
+        if name == "serena.tools.workflow_tools":
+            return ToolsMod
+        if name == "serena.prompt_factory":
+            return PromptMod
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(serena_tools, "import_module", fake_import)
+    serena_tools.clear_serena_imports()
+    tool_enum = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
+    serena_tools.clear_serena_imports()
+    tool_str = server.create_serena_tool("LIST_DIAGNOSTICS")
+    assert type(tool_enum) is type(tool_str)

--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -41,7 +41,10 @@ def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Contex
             severity: str | None = None,
             files: list[str] | None = None,
         ) -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-            tool = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
+            tool = typ.cast(
+                typ.Any,  # noqa: TC006
+                server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS),
+            )
             for d in tool.list_diagnostics():
                 if severity and d.severity != severity:
                     continue

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -1,5 +1,6 @@
 import json
 import os
+import typing as typ
 from pathlib import Path
 
 import msgspec as ms
@@ -22,7 +23,7 @@ def runtime_dir(runtime_dir: Context) -> Context:
         async def onboard() -> OnboardingReport:  # pragma: no cover - stub
             if os.environ.get("WEAVER_TEST_MISSING_SERENA"):
                 raise RuntimeError("serena-agent not found")
-            tool = create_serena_tool(SerenaTool.ONBOARDING)
+            tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.ONBOARDING))  # noqa: TC006
             return OnboardingReport(details=tool.apply())
 
     runtime_dir["register"](setup)

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -30,6 +30,9 @@ def clear_serena_imports() -> None:
     Tests use this helper to force ``import_module`` to attempt a fresh import.
     The standard ``sys.modules`` cache is cleared for the Serena modules used by
     :func:`create_serena_tool`.
+
+    This helper mutates ``sys.modules`` without any locking and is therefore
+    not thread-safe. It is intended for single-threaded test contexts only.
     """
 
     for name in ("serena.tools.workflow_tools", "serena.prompt_factory"):
@@ -51,25 +54,8 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
       ``TypeError`` if ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
     """
 
-    try:
-        wf_tools = import_module("serena.tools.workflow_tools")
-        prompt_mod = import_module("serena.prompt_factory")
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        msg = "serena-agent is required; install it via 'uv add serena-agent'."
-        raise RuntimeError(msg) from exc
-
-    if isinstance(tool_attr, SerenaTool):
-        name = tool_attr.value
-    elif isinstance(tool_attr, str):
-        upper = tool_attr.upper()
-        if upper in SerenaTool.__members__:
-            name = SerenaTool[upper].value
-        elif tool_attr in {t.value for t in SerenaTool}:
-            name = tool_attr
-        else:
-            raise RuntimeError(f"Unknown Serena tool '{tool_attr}'")
-    else:
-        raise TypeError("tool_attr must be SerenaTool or str")
+    wf_tools, prompt_mod = _load_serena_modules()
+    name = _resolve_tool_name(tool_attr)
 
     tool_cls = getattr(wf_tools, name, None)
     if tool_cls is None:
@@ -77,7 +63,38 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
     if not callable(tool_cls):
         raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
 
+    # Assumption: SerenaPromptFactory can be instantiated without arguments.
     return tool_cls(_BareAgent(prompt_mod.SerenaPromptFactory()))
+
+
+def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
+    """Resolve ``tool_attr`` to the actual workflow tool class name."""
+
+    if isinstance(tool_attr, SerenaTool):
+        return tool_attr.value
+
+    if not isinstance(tool_attr, str):
+        raise TypeError("tool_attr must be SerenaTool or str")
+
+    upper = tool_attr.upper()
+    if upper in SerenaTool.__members__:
+        return SerenaTool[upper].value
+    if tool_attr in {t.value for t in SerenaTool}:
+        return tool_attr
+    raise RuntimeError(f"Unknown Serena tool '{tool_attr}'")
+
+
+def _load_serena_modules() -> tuple[typ.Any, typ.Any]:
+    """Load the Serena workflow tools and prompt factory modules."""
+
+    try:
+        wf_tools = import_module("serena.tools.workflow_tools")
+        prompt_mod = import_module("serena.prompt_factory")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+        msg = "serena-agent is required; install it via 'uv add serena-agent'."
+        raise RuntimeError(msg) from exc
+
+    return wf_tools, prompt_mod
 
 
 class _BareAgent:

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -20,6 +20,12 @@ else:  # pragma: no cover - import-time only
         """Typed placeholder used when Serena is not installed."""
 
 
+# Opaque tool instance returned by Serena; interface comes from serena-agent.
+# We expose it as ``object`` to avoid ``Any`` in the public API while keeping it
+# flexible.
+SerenaToolInstance: typ.TypeAlias = object
+
+
 class SerenaTool(enum.StrEnum):
     """Supported Serena tools."""
 
@@ -54,19 +60,27 @@ def clear_serena_imports() -> None:
         sys.modules.pop(name, None)
 
 
-def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
-    """Instantiate a Serena tool from its enum member or raw attribute name.
+def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolInstance:
+    """Instantiate a Serena tool.
 
-    Accepts:
-      - ``SerenaTool`` enum member, e.g. ``SerenaTool.ONBOARDING``
-      - ``str``: either the enum member name (case-insensitive, ``"ONBOARDING"``)
-        or the ``serena.tools.workflow_tools`` attribute name
-        (``"OnboardingTool"``).
+    Parameters
+    ----------
+    tool_attr:
+        ``SerenaTool`` enum member or string. Enum member names are
+        case-insensitive; raw class names are also accepted.
 
-    Raises:
-      ``RuntimeError`` if the tool class is not found or not callable.
-      ``RuntimeError`` if ``tool_attr`` is an unknown string.
-      ``TypeError`` if ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
+    Returns
+    -------
+    SerenaToolInstance
+        Instantiated Serena tool.
+
+    Raises
+    ------
+    RuntimeError
+        If the tool class is not found, not callable or ``tool_attr`` is an
+        unknown string.
+    TypeError
+        If ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
     """
 
     wf_tools, prompt_mod = _load_serena_modules()
@@ -80,7 +94,12 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
 
     # Assumption: SerenaPromptFactory can be instantiated without arguments.
     try:
-        prompt_factory_cls = typ.cast(typ.Any, prompt_mod).SerenaPromptFactory  # noqa: TC006
+        prompt_factory_attr = getattr(prompt_mod, "SerenaPromptFactory", None)
+        if not isinstance(prompt_factory_attr, type):
+            raise RuntimeError(
+                "serena.prompt_factory.SerenaPromptFactory not found or not a type"
+            )
+        prompt_factory_cls = typ.cast("type[SerenaPromptFactory]", prompt_factory_attr)
         agent = _BareAgent(prompt_factory_cls())
         return tool_cls(agent)
     except Exception as exc:
@@ -118,12 +137,19 @@ def _resolve_string_tool_name(tool_name: str) -> str:
 def _load_serena_modules() -> tuple[ModuleType, ModuleType]:
     """Load the Serena workflow tools and prompt factory modules."""
 
+    msg = "serena-agent is required; install it via 'uv add serena-agent'."
     try:
         wf_tools = import_module("serena.tools.workflow_tools")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+        if getattr(exc, "name", "") and str(exc.name).startswith("serena"):
+            raise RuntimeError(msg) from exc
+        raise
+    try:
         prompt_mod = import_module("serena.prompt_factory")
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        msg = "serena-agent is required; install it via 'uv add serena-agent'."
-        raise RuntimeError(msg) from exc
+        if getattr(exc, "name", "") and str(exc.name).startswith("serena"):
+            raise RuntimeError(msg) from exc
+        raise
 
     return wf_tools, prompt_mod
 
@@ -133,7 +159,7 @@ class _BareAgent:
 
     __slots__ = ("prompt_factory",)
 
-    def __init__(self, prompt_factory: typ.Any) -> None:
+    def __init__(self, prompt_factory: SerenaPromptFactory) -> None:
         self.prompt_factory = prompt_factory
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -60,6 +60,43 @@ def clear_serena_imports() -> None:
         sys.modules.pop(name, None)
 
 
+def _validate_and_get_tool_class(wf_tools: ModuleType, name: str) -> typ.Any:
+    """Return the workflow tool class, ensuring it exists and is callable."""
+
+    tool_cls = getattr(wf_tools, name, None)
+    if tool_cls is None:
+        raise RuntimeError(f"serena.tools.workflow_tools.{name} not found")
+    if not callable(tool_cls):
+        raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
+    return tool_cls
+
+
+def _create_agent_with_prompt_factory(prompt_mod: ModuleType) -> _BareAgent:
+    """Create an agent using ``SerenaPromptFactory`` from ``prompt_mod``."""
+
+    # Assumption: SerenaPromptFactory can be instantiated without arguments.
+    prompt_factory_attr = getattr(prompt_mod, "SerenaPromptFactory", None)
+    if not isinstance(prompt_factory_attr, type):
+        raise RuntimeError(
+            "serena.prompt_factory.SerenaPromptFactory not found or not a type",
+        )
+    prompt_factory_cls = typ.cast("type[SerenaPromptFactory]", prompt_factory_attr)
+    return _BareAgent(prompt_factory_cls())
+
+
+def _instantiate_tool(
+    tool_cls: typ.Any, agent: _BareAgent, name: str
+) -> SerenaToolInstance:
+    """Instantiate ``tool_cls`` with ``agent`` and wrap errors."""
+
+    try:
+        return tool_cls(agent)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to instantiate serena.tools.workflow_tools.{name}: {exc}",
+        ) from exc
+
+
 def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolInstance:
     """Instantiate a Serena tool.
 
@@ -85,27 +122,12 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolInstance:
 
     wf_tools, prompt_mod = _load_serena_modules()
     name = _resolve_tool_name(tool_attr)
-
-    tool_cls = getattr(wf_tools, name, None)
-    if tool_cls is None:
-        raise RuntimeError(f"serena.tools.workflow_tools.{name} not found")
-    if not callable(tool_cls):
-        raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
-
-    # Assumption: SerenaPromptFactory can be instantiated without arguments.
-    try:
-        prompt_factory_attr = getattr(prompt_mod, "SerenaPromptFactory", None)
-        if not isinstance(prompt_factory_attr, type):
-            raise RuntimeError(
-                "serena.prompt_factory.SerenaPromptFactory not found or not a type"
-            )
-        prompt_factory_cls = typ.cast("type[SerenaPromptFactory]", prompt_factory_attr)
-        agent = _BareAgent(prompt_factory_cls())
-        return tool_cls(agent)
-    except Exception as exc:
-        raise RuntimeError(
-            f"Failed to instantiate serena.tools.workflow_tools.{name}: {exc}"
-        ) from exc
+    tool_cls = _validate_and_get_tool_class(wf_tools, name)
+    return _instantiate_tool(
+        tool_cls,
+        _create_agent_with_prompt_factory(prompt_mod),
+        name,
+    )
 
 
 def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
@@ -134,23 +156,23 @@ def _resolve_string_tool_name(tool_name: str) -> str:
     )
 
 
-def _load_serena_modules() -> tuple[ModuleType, ModuleType]:
-    """Load the Serena workflow tools and prompt factory modules."""
+def _import_serena_module(module_name: str) -> ModuleType:
+    """Import a Serena module with consistent error handling."""
 
     msg = "serena-agent is required; install it via 'uv add serena-agent'."
     try:
-        wf_tools = import_module("serena.tools.workflow_tools")
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        if getattr(exc, "name", "") and str(exc.name).startswith("serena"):
-            raise RuntimeError(msg) from exc
-        raise
-    try:
-        prompt_mod = import_module("serena.prompt_factory")
+        return import_module(module_name)
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
         if getattr(exc, "name", "") and str(exc.name).startswith("serena"):
             raise RuntimeError(msg) from exc
         raise
 
+
+def _load_serena_modules() -> tuple[ModuleType, ModuleType]:
+    """Load the Serena workflow tools and prompt factory modules."""
+
+    wf_tools = _import_serena_module("serena.tools.workflow_tools")
+    prompt_mod = _import_serena_module("serena.prompt_factory")
     return wf_tools, prompt_mod
 
 

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-import dataclasses
 import enum
+import sys
 import typing as typ
-from functools import cache
 from importlib import import_module
 
 # pyright: reportMissingImports=false  # Serena optional dependency
 
 if typ.TYPE_CHECKING:  # pragma: no cover - import-time only
-    from types import ModuleType
-
     from serena.prompt_factory import SerenaPromptFactory
 else:  # pragma: no cover - import-time only
 
@@ -27,72 +24,64 @@ class SerenaTool(enum.StrEnum):
     LIST_DIAGNOSTICS = "ListDiagnosticsTool"
 
 
-@cache
-def _serena_modules() -> tuple[ModuleType, type[SerenaPromptFactory]]:
-    """Return workflow tools module and prompt factory."""
+def clear_serena_imports() -> None:
+    """Remove cached Serena modules.
+
+    Tests use this helper to force ``import_module`` to attempt a fresh import.
+    The standard ``sys.modules`` cache is cleared for the Serena modules used by
+    :func:`create_serena_tool`.
+    """
+
+    for name in ("serena.tools.workflow_tools", "serena.prompt_factory"):
+        sys.modules.pop(name, None)
+
+
+def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
+    """Instantiate a Serena tool from its enum member or raw attribute name.
+
+    Accepts:
+      - ``SerenaTool`` enum member, e.g. ``SerenaTool.ONBOARDING``
+      - ``str``: either the enum member name (case-insensitive, ``"ONBOARDING"``)
+        or the ``serena.tools.workflow_tools`` attribute name
+        (``"OnboardingTool"``).
+
+    Raises:
+      ``RuntimeError`` if the tool class is not found or not callable.
+      ``RuntimeError`` if ``tool_attr`` is an unknown string.
+      ``TypeError`` if ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
+    """
 
     try:
         wf_tools = import_module("serena.tools.workflow_tools")
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        msg = "serena-agent is required; install it via 'uv add serena-agent'."
-        raise RuntimeError(msg) from exc
-    try:
         prompt_mod = import_module("serena.prompt_factory")
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
         msg = "serena-agent is required; install it via 'uv add serena-agent'."
         raise RuntimeError(msg) from exc
-    return wf_tools, prompt_mod.SerenaPromptFactory
-
-
-class SerenaToolProtocol(typ.Protocol):
-    """Expected interface for Serena tools."""
-
-    def run(self, *args: object, **kwargs: object) -> object: ...
-    def __getattr__(self, name: str) -> typ.Any: ...
-
-
-def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
-    """Normalise tool identifiers to workflow attribute names."""
 
     if isinstance(tool_attr, SerenaTool):
-        return tool_attr.value
-    if isinstance(tool_attr, str):
-        try:
-            # Allow enum member names such as "ONBOARDING".
-            return SerenaTool[tool_attr].value
-        except KeyError:
-            return tool_attr
-    raise TypeError("tool_attr must be SerenaTool or str")
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class _Agent:
-    """Minimal agent providing only the prompt factory."""
-
-    prompt_factory: SerenaPromptFactory
-
-
-def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolProtocol:
-    """Instantiate a Serena tool.
-
-    Accepts:
-      - ``SerenaTool`` enum member, e.g. ``SerenaTool.ONBOARDING``
-      - ``str``: either the enum member name (``"ONBOARDING"``) or the
-        ``serena.tools.workflow_tools`` attribute name (``"OnboardingTool"``).
-
-    Raises:
-      ``RuntimeError`` if the tool class is not found or not callable.
-      ``TypeError`` if ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
-    """
-
-    wf_tools, prompt_factory_cls = _serena_modules()
-    name = _resolve_tool_name(tool_attr)
+        name = tool_attr.value
+    elif isinstance(tool_attr, str):
+        upper = tool_attr.upper()
+        if upper in SerenaTool.__members__:
+            name = SerenaTool[upper].value
+        elif tool_attr in {t.value for t in SerenaTool}:
+            name = tool_attr
+        else:
+            raise RuntimeError(f"Unknown Serena tool '{tool_attr}'")
+    else:
+        raise TypeError("tool_attr must be SerenaTool or str")
 
     tool_cls = getattr(wf_tools, name, None)
-    if tool_cls is None:  # pragma: no cover - optional dep
+    if tool_cls is None:
         raise RuntimeError(f"serena.tools.workflow_tools.{name} not found")
-    if not callable(tool_cls):  # pragma: no cover - defensive
+    if not callable(tool_cls):
         raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
 
-    agent = _Agent(prompt_factory_cls())
-    return typ.cast("SerenaToolProtocol", tool_cls(agent))
+    return tool_cls(_BareAgent(prompt_mod.SerenaPromptFactory()))
+
+
+class _BareAgent:
+    """Minimal agent providing only the prompt factory."""
+
+    def __init__(self, prompt_factory: typ.Any) -> None:
+        self.prompt_factory = prompt_factory

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -89,14 +89,20 @@ def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
     if not isinstance(tool_attr, str):
         raise TypeError("tool_attr must be SerenaTool or str")
 
-    upper = tool_attr.upper()
+    return _resolve_string_tool_name(tool_attr)
+
+
+def _resolve_string_tool_name(tool_name: str) -> str:
+    """Resolve ``tool_name`` to the actual workflow tool class name."""
+
+    upper = tool_name.upper()
     if upper in SerenaTool.__members__:
         return SerenaTool[upper].value
-    if tool_attr in {t.value for t in SerenaTool}:
-        return tool_attr
+    if tool_name in {t.value for t in SerenaTool}:
+        return tool_name
     valid = sorted(list(SerenaTool.__members__) + [t.value for t in SerenaTool])
     raise RuntimeError(
-        f"Unknown Serena tool '{tool_attr}'. Expected one of: {', '.join(valid)}"
+        f"Unknown Serena tool '{tool_name}'. Expected one of: {', '.join(valid)}"
     )
 
 

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -27,6 +27,10 @@ class SerenaTool(enum.StrEnum):
     LIST_DIAGNOSTICS = "ListDiagnosticsTool"
 
 
+_VALID_TOOL_MEMBER_NAMES = frozenset(SerenaTool.__members__.keys())
+_VALID_TOOL_VALUES = frozenset(t.value for t in SerenaTool)
+
+
 def clear_serena_imports() -> None:
     """Remove cached Serena modules.
 
@@ -41,7 +45,12 @@ def clear_serena_imports() -> None:
     # Optional: ensure import finders don't use stale filesystem caches.
     with suppress(Exception):  # pragma: no cover - best effort
         invalidate_caches()
-    for name in ("serena.tools.workflow_tools", "serena.prompt_factory"):
+    for name in (
+        "serena.tools.workflow_tools",
+        "serena.prompt_factory",
+        "serena.tools",
+        "serena",
+    ):
         sys.modules.pop(name, None)
 
 
@@ -96,11 +105,11 @@ def _resolve_string_tool_name(tool_name: str) -> str:
     """Resolve ``tool_name`` to the actual workflow tool class name."""
 
     upper = tool_name.upper()
-    if upper in SerenaTool.__members__:
+    if upper in _VALID_TOOL_MEMBER_NAMES:
         return SerenaTool[upper].value
-    if tool_name in {t.value for t in SerenaTool}:
+    if tool_name in _VALID_TOOL_VALUES:
         return tool_name
-    valid = sorted(list(SerenaTool.__members__) + [t.value for t in SerenaTool])
+    valid = sorted({*_VALID_TOOL_MEMBER_NAMES, *_VALID_TOOL_VALUES})
     raise RuntimeError(
         f"Unknown Serena tool '{tool_name}'. Expected one of: {', '.join(valid)}"
     )

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import enum
 import sys
 import typing as typ
-from importlib import import_module
+from contextlib import suppress
+from importlib import import_module, invalidate_caches
 
 # pyright: reportMissingImports=false  # Serena optional dependency
 
 if typ.TYPE_CHECKING:  # pragma: no cover - import-time only
+    from types import ModuleType
+
     from serena.prompt_factory import SerenaPromptFactory
 else:  # pragma: no cover - import-time only
 
@@ -35,6 +38,9 @@ def clear_serena_imports() -> None:
     not thread-safe. It is intended for single-threaded test contexts only.
     """
 
+    # Optional: ensure import finders don't use stale filesystem caches.
+    with suppress(Exception):  # pragma: no cover - best effort
+        invalidate_caches()
     for name in ("serena.tools.workflow_tools", "serena.prompt_factory"):
         sys.modules.pop(name, None)
 
@@ -64,7 +70,14 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> typ.Any:
         raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
 
     # Assumption: SerenaPromptFactory can be instantiated without arguments.
-    return tool_cls(_BareAgent(prompt_mod.SerenaPromptFactory()))
+    try:
+        prompt_factory_cls = typ.cast(typ.Any, prompt_mod).SerenaPromptFactory  # noqa: TC006
+        agent = _BareAgent(prompt_factory_cls())
+        return tool_cls(agent)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to instantiate serena.tools.workflow_tools.{name}: {exc}"
+        ) from exc
 
 
 def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
@@ -81,10 +94,13 @@ def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
         return SerenaTool[upper].value
     if tool_attr in {t.value for t in SerenaTool}:
         return tool_attr
-    raise RuntimeError(f"Unknown Serena tool '{tool_attr}'")
+    valid = sorted(list(SerenaTool.__members__) + [t.value for t in SerenaTool])
+    raise RuntimeError(
+        f"Unknown Serena tool '{tool_attr}'. Expected one of: {', '.join(valid)}"
+    )
 
 
-def _load_serena_modules() -> tuple[typ.Any, typ.Any]:
+def _load_serena_modules() -> tuple[ModuleType, ModuleType]:
     """Load the Serena workflow tools and prompt factory modules."""
 
     try:
@@ -100,5 +116,10 @@ def _load_serena_modules() -> tuple[typ.Any, typ.Any]:
 class _BareAgent:
     """Minimal agent providing only the prompt factory."""
 
+    __slots__ = ("prompt_factory",)
+
     def __init__(self, prompt_factory: typ.Any) -> None:
         self.prompt_factory = prompt_factory
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"_BareAgent(prompt_factory={type(self.prompt_factory).__name__})"

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -117,7 +117,7 @@ async def handle_project_status() -> ProjectStatus:
 @rpc_handler("onboard-project")
 async def handle_onboard_project() -> OnboardingReport:
     """Run the onboarding tool and return its report."""
-    tool = create_serena_tool(SerenaTool.ONBOARDING)
+    tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.ONBOARDING))  # noqa: TC006
     try:
         details = await asyncio.to_thread(tool.apply)
     except Exception as exc:  # pragma: no cover - unexpected failures
@@ -175,7 +175,7 @@ async def handle_list_diagnostics(
     # Prepare filters for case- and path-insensitive comparison
     norm_severity, norm_files = _normalize_filters(severity, files)
 
-    tool = create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
+    tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.LIST_DIAGNOSTICS))  # noqa: TC006
     try:
         data = await asyncio.to_thread(tool.list_diagnostics)
     except RuntimeError as exc:

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -104,11 +104,31 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
         raise ModuleNotFoundError
 
     monkeypatch.setattr(serena_tools, "import_module", fake_import)
-    serena_tools._serena_modules.cache_clear()
+    serena_tools.clear_serena_imports()
 
     with pytest.raises(RuntimeError, match="workflow_tools.OnboardingTool"):
         serena_tools.create_serena_tool(SerenaTool.ONBOARDING)
-    serena_tools._serena_modules.cache_clear()
+    serena_tools.clear_serena_imports()
+
+    class NonCallableTool:  # pragma: no cover - simple stub
+        pass
+
+    def fake_import_noncallable(name: str) -> typ.Any:  # pragma: no cover - stub
+        if name == "serena.tools.workflow_tools":
+
+            class Tools:  # pragma: no cover - stub
+                OnboardingTool = NonCallableTool()  # not callable
+
+            return Tools
+        if name == "serena.prompt_factory":
+            return PromptMod
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(serena_tools, "import_module", fake_import_noncallable)
+    serena_tools.clear_serena_imports()
+    with pytest.raises(RuntimeError, match="not callable"):
+        serena_tools.create_serena_tool(SerenaTool.ONBOARDING)
+    serena_tools.clear_serena_imports()
 
 
 @pytest.mark.anyio

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -98,7 +98,7 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
         if name == "serena.tools.workflow_tools":
-            return ToolsMod()
+            return ToolsMod
         if name == "serena.prompt_factory":
             return PromptMod
         raise ModuleNotFoundError

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -51,7 +51,7 @@ async def diagnostics_test_server(
         severity: str | None = None,
         files: list[str] | None = None,
     ) -> typ.AsyncIterator[Diagnostic]:
-        tool = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
+        tool = typ.cast(typ.Any, server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS))  # noqa: TC006
         for diag in tool.list_diagnostics():
             if severity and diag.severity != severity:
                 continue
@@ -165,7 +165,7 @@ async def test_missing_diagnostics_dependency(
 
     @dispatcher.register("list-diagnostics")
     async def handler() -> typ.AsyncIterator[Diagnostic]:  # pragma: no cover - stub
-        tool = server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
+        tool = typ.cast(typ.Any, server.create_serena_tool(SerenaTool.LIST_DIAGNOSTICS))  # noqa: TC006
         for d in tool.list_diagnostics():
             yield d
 

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -10,6 +10,7 @@ import msgspec.json as msjson
 import pytest
 
 from weaver_schemas.reports import OnboardingReport
+from weaverd import serena_tools
 from weaverd.rpc import RPCDispatcher
 from weaverd.serena_tools import SerenaTool, create_serena_tool
 from weaverd.server import start_server
@@ -81,3 +82,33 @@ async def test_onboard_failure(tmp_path: Path) -> None:
             await writer.wait_closed()
     server.close()
     await server.wait_closed()
+
+
+def test_create_serena_tool_with_invalid_tool_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_serena_tool should raise for unknown tools."""
+
+    class ToolsMod:  # pragma: no cover - simple stub
+        class OnboardingTool:  # pragma: no cover - simple stub
+            def __init__(self, _: typ.Any) -> None:  # pragma: no cover - stub
+                pass
+
+    class PromptMod:  # pragma: no cover - simple stub
+        class SerenaPromptFactory:  # pragma: no cover - simple stub
+            def __call__(self) -> None:  # pragma: no cover - stub
+                return None
+
+    def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
+        if name == "serena.tools.workflow_tools":
+            return ToolsMod
+        if name == "serena.prompt_factory":
+            return PromptMod
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(serena_tools, "import_module", fake_import)
+    serena_tools.clear_serena_imports()
+
+    with pytest.raises(RuntimeError, match="NonExistentTool"):
+        create_serena_tool("NonExistentTool")
+    serena_tools.clear_serena_imports()

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -26,7 +26,7 @@ async def test_onboard_project(tmp_path: Path) -> None:
 
     @dispatcher.register("onboard-project")
     async def onboard() -> OnboardingReport:  # pyright: ignore[reportUnusedFunction]
-        tool = create_serena_tool(SerenaTool.ONBOARDING)
+        tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.ONBOARDING))  # noqa: TC006
         return OnboardingReport(details=tool.apply())
 
     sock = tmp_path / "o.sock"

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -10,7 +10,6 @@ import msgspec.json as msjson
 import pytest
 
 from weaver_schemas.reports import OnboardingReport
-from weaverd import serena_tools
 from weaverd.rpc import RPCDispatcher
 from weaverd.serena_tools import SerenaTool, create_serena_tool
 from weaverd.server import start_server
@@ -84,31 +83,8 @@ async def test_onboard_failure(tmp_path: Path) -> None:
     await server.wait_closed()
 
 
-def test_create_serena_tool_with_invalid_tool_name(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_create_serena_tool_with_invalid_tool_name() -> None:
     """create_serena_tool should raise for unknown tools."""
-
-    class ToolsMod:  # pragma: no cover - simple stub
-        class OnboardingTool:  # pragma: no cover - simple stub
-            def __init__(self, _: typ.Any) -> None:  # pragma: no cover - stub
-                pass
-
-    class PromptMod:  # pragma: no cover - simple stub
-        class SerenaPromptFactory:  # pragma: no cover - simple stub
-            def __call__(self) -> None:  # pragma: no cover - stub
-                return None
-
-    def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
-        if name == "serena.tools.workflow_tools":
-            return ToolsMod
-        if name == "serena.prompt_factory":
-            return PromptMod
-        raise ModuleNotFoundError
-
-    monkeypatch.setattr(serena_tools, "import_module", fake_import)
-    serena_tools.clear_serena_imports()
 
     with pytest.raises(RuntimeError, match="NonExistentTool"):
         create_serena_tool("NonExistentTool")
-    serena_tools.clear_serena_imports()

--- a/weaverd/unittests/test_serena_tools.py
+++ b/weaverd/unittests/test_serena_tools.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from weaverd.serena_tools import _resolve_string_tool_name, _resolve_tool_name
+
+
+def test_resolve_string_tool_name_enum_case_insensitive() -> None:
+    assert _resolve_string_tool_name("onboarding") == "OnboardingTool"
+
+
+def test_resolve_string_tool_name_direct_value() -> None:
+    assert _resolve_string_tool_name("OnboardingTool") == "OnboardingTool"
+
+
+def test_resolve_string_tool_name_unknown() -> None:
+    with pytest.raises(RuntimeError, match="Unknown Serena tool 'Nope'"):
+        _resolve_string_tool_name("Nope")
+
+
+def test_resolve_tool_name_type_error() -> None:
+    with pytest.raises(TypeError):
+        _resolve_tool_name(123)  # type: ignore[arg-type]

--- a/weaverd/unittests/test_serena_tools.py
+++ b/weaverd/unittests/test_serena_tools.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import pytest
 
-from weaverd.serena_tools import _resolve_string_tool_name, _resolve_tool_name
+from weaverd.serena_tools import (
+    SerenaTool,
+    _resolve_string_tool_name,
+    _resolve_tool_name,
+)
 
 
-def test_resolve_string_tool_name_enum_case_insensitive() -> None:
-    assert _resolve_string_tool_name("onboarding") == "OnboardingTool"
-
-
-def test_resolve_string_tool_name_direct_value() -> None:
-    assert _resolve_string_tool_name("OnboardingTool") == "OnboardingTool"
+@pytest.mark.parametrize(
+    ("input_name", "expected"),
+    [
+        ("onboarding", "OnboardingTool"),
+        ("OnboardingTool", "OnboardingTool"),
+    ],
+)
+def test_resolve_string_tool_name_success(input_name: str, expected: str) -> None:
+    assert _resolve_string_tool_name(input_name) == expected
 
 
 def test_resolve_string_tool_name_unknown() -> None:
@@ -21,3 +28,7 @@ def test_resolve_string_tool_name_unknown() -> None:
 def test_resolve_tool_name_type_error() -> None:
     with pytest.raises(TypeError):
         _resolve_tool_name(123)  # type: ignore[arg-type]
+
+
+def test_resolve_tool_name_from_enum() -> None:
+    assert _resolve_tool_name(SerenaTool.ONBOARDING) == "OnboardingTool"


### PR DESCRIPTION
## Summary
- Inline Serena tool imports and validation into a single helper
- Offer a public helper to clear cached Serena imports for tests
- Expand diagnostics and onboarding tests, including string/enum compatibility and non-callable tools

## Testing
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68979268ec7c8322844d7e6f29103902

## Summary by Sourcery

Simplify the creation and management of Serena workflow tools by consolidating import and validation logic, removing the internal cache mechanism, and exposing a helper to clear cached imports for testing, while adding comprehensive tests for string/enum tool resolution and error scenarios

New Features:
- Expose clear_serena_imports helper to reset cached Serena modules

Enhancements:
- Inline module imports and tool name resolution in create_serena_tool, removing the previous cache-based loader and protocol
- Replace internal caching and protocol classes with runtime import logic and a minimal BareAgent wrapper

Tests:
- Add tests to verify create_serena_tool accepts both enum and string identifiers
- Add tests for invalid tool names and non-callable tool classes to ensure proper error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool creation accepts either enum members or equivalent string names.

* **Bug Fixes**
  * On-demand tool loading with ability to clear stale module state for more reliable behavior.
  * Clearer, user-friendly errors when a requested tool is unknown or not callable.

* **Tests**
  * Added tests for enum/string equivalence, invalid-tool errors, and non-callable tool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->