### PR TITLE
Implement get-definition command

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,7 @@ This phase focuses on wrapping Serena's tool capabilities.*
 
 - [ ] **Implement Orient Commands:**
 
-  - [ ] `get-definition`: Implement the handler to call the definition-fetching
+  - [x] `get-definition`: Implement the handler to call the definition-fetching
     method in Serena's tools.
 
   - [ ] `list-references`: Implement the handler to call the reference-finding

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -169,6 +169,11 @@ the `rss_mb` field. The response reports the daemon process ID, resident memory
 | get-type-hierarchy | `--direction <super|sub> <file> <line> <char>` Show type hierarchy for the symbol.        |
 | list-memories      | Stream previously stored memory snippets.                                                 |
 
+The `get-definition` handler invokes Serena's `GetDefinitionTool`. The daemon
+passes the file and 0-indexed cursor position to the tool on a worker thread
+and streams each resulting `Symbol` structure back to the client. This mirrors
+the LSP definition request while remaining JSONL-friendly and non-blocking.
+
 ### 2.3 Decide
 
 | Command             | Synopsis                                                                                |
@@ -276,14 +281,14 @@ then generates an `OnboardingReport` returned to the client. In tests, the
 creation function can be patched to raise a runtime error to simulate a missing
 dependency.
 
-Both onboarding and diagnostics tools share common import logic. A helper in the
-daemon loads the requested Serena tool and prompt factory, raising a
+Both onboarding and diagnostics tools share common import logic. A helper in
+the daemon loads the requested Serena tool and prompt factory, raising a
 user-friendly ``RuntimeError`` if ``serena-agent`` is missing.
 
 `list-diagnostics` relies on Serena's `ListDiagnosticsTool`. The handler
 initialises the tool with a new `SerenaPromptFactory`, invokes
-`list_diagnostics` in a background thread and yields each dictionary through the
-RPC stream after converting it to the internal `Diagnostic` model using
+`list_diagnostics` in a background thread and yields each dictionary through
+the RPC stream after converting it to the internal `Diagnostic` model using
 `msgspec.convert`. Optional `severity` and `files` parameters filter the
 diagnostics while streaming, avoiding large in-memory collections.
 

--- a/features/get_definition.feature
+++ b/features/get_definition.feature
@@ -1,0 +1,11 @@
+Feature: get definition command
+  Scenario: daemon auto-start
+    Given a temporary runtime dir
+    When I invoke the get-definition command
+    Then the output includes a symbol line
+
+  Scenario: missing serena-agent dependency
+    Given a temporary runtime dir
+    And serena-agent is missing
+    When I invoke the get-definition command
+    Then the daemon is not ready

--- a/features/get_definition.feature
+++ b/features/get_definition.feature
@@ -4,8 +4,18 @@ Feature: get definition command
     When I invoke the get-definition command
     Then the output includes a symbol line
 
+  Scenario: no symbol at position
+    Given a temporary runtime dir with no symbols
+    When I invoke the get-definition command
+    Then no output is produced
+
   Scenario: missing serena-agent dependency
     Given a temporary runtime dir
     And serena-agent is missing
     When I invoke the get-definition command
     Then the daemon is not ready
+
+  Scenario: file not found
+    Given a temporary runtime dir
+    When I invoke the get-definition command with a missing file
+    Then the command fails with a missing file error

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -17,50 +17,54 @@ from weaverd.serena_tools import SerenaTool
 scenarios("../get_definition.feature")
 
 
+def _create_runtime_fixture(
+    get_definition_impl: cabc.Callable[[str, int, int], list[Symbol]],
+) -> cabc.Callable[[Context, pytest.MonkeyPatch], Context]:
+    """Return a fixture that configures a stubbed get-definition tool."""
+
+    def _fixture(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+        class StubTool:
+            def get_definition(
+                self, *, file: str, line: int, char: int
+            ) -> list[Symbol]:
+                return get_definition_impl(file, line, char)
+
+        monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+
+        def setup(dispatcher: RPCDispatcher) -> None:
+            @dispatcher.register("get-definition")
+            async def handler(
+                file: str, line: int, char: int
+            ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
+                tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
+                for sym in tool.get_definition(file=file, line=line, char=char):
+                    yield sym
+
+        runtime_dir["register"](setup)
+        return runtime_dir
+
+    return _fixture
+
+
+def _return_foo_symbol(file: str, line: int, char: int) -> list[Symbol]:
+    loc = Location(
+        file=file, range=Range(start=Position(line, char), end=Position(line, char + 1))
+    )
+    return [Symbol(name="foo", kind="function", location=loc)]
+
+
+def _return_no_symbols(file: str, line: int, char: int) -> list[Symbol]:
+    return []
+
+
 @given("a temporary runtime dir", target_fixture="context")
 def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
-    class StubTool:
-        def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
-            loc = Location(
-                file=file,
-                range=Range(start=Position(line, char), end=Position(line, char + 1)),
-            )
-            return [Symbol(name="foo", kind="function", location=loc)]
-
-    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
-
-    def setup(dispatcher: RPCDispatcher) -> None:
-        @dispatcher.register("get-definition")
-        async def handler(
-            file: str, line: int, char: int
-        ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
-            tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
-            for sym in tool.get_definition(file=file, line=line, char=char):
-                yield sym
-
-    runtime_dir["register"](setup)
-    return runtime_dir
+    return _create_runtime_fixture(_return_foo_symbol)(runtime_dir, monkeypatch)
 
 
 @given("a temporary runtime dir with no symbols", target_fixture="context")
 def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
-    class StubTool:
-        def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
-            return []
-
-    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
-
-    def setup(dispatcher: RPCDispatcher) -> None:
-        @dispatcher.register("get-definition")
-        async def handler(
-            file: str, line: int, char: int
-        ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
-            tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
-            for sym in tool.get_definition(file=file, line=line, char=char):
-                yield sym
-
-    runtime_dir["register"](setup)
-    return runtime_dir
+    return _create_runtime_fixture(_return_no_symbols)(runtime_dir, monkeypatch)
 
 
 @given("serena-agent is missing")
@@ -72,13 +76,15 @@ def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @when("I invoke the get-definition command")
-def invoke(context: Context) -> None:
-    file = Path("foo.py")
+def invoke(context: Context, tmp_path: Path) -> None:
+    file = tmp_path / "foo.py"
     file.write_text("pass")
     runner = CliRunner()
-    result = runner.invoke(app, ["get-definition", "foo.py", "1", "0"])
-    context["result"] = result
-    file.unlink(missing_ok=True)
+    try:
+        result = runner.invoke(app, ["get-definition", str(file), "1", "0"])
+        context["result"] = result
+    finally:
+        file.unlink(missing_ok=True)
 
 
 @when("I invoke the get-definition command with a missing file")

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -1,0 +1,71 @@
+import collections.abc as cabc
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+from typer.testing import CliRunner
+
+from features.types import Context
+from weaver.cli import app
+from weaver_schemas.primitives import Location, Position, Range
+from weaver_schemas.references import Symbol
+from weaverd import server
+from weaverd.rpc import RPCDispatcher
+from weaverd.serena_tools import SerenaTool
+
+scenarios("../get_definition.feature")
+
+
+@given("a temporary runtime dir", target_fixture="context")
+def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+    class StubTool:
+        def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+            loc = Location(
+                file=file,
+                range=Range(start=Position(line, char), end=Position(line, char + 1)),
+            )
+            return [Symbol(name="foo", kind="function", location=loc)]
+
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+
+    def setup(dispatcher: RPCDispatcher) -> None:
+        @dispatcher.register("get-definition")
+        async def handler(
+            file: str, line: int, char: int
+        ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
+            tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
+            for sym in tool.get_definition(file=file, line=line, char=char):
+                yield sym
+
+    runtime_dir["register"](setup)
+    return runtime_dir
+
+
+@given("serena-agent is missing")
+def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_error(_: SerenaTool) -> None:
+        raise RuntimeError("serena-agent not found")
+
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+
+
+@when("I invoke the get-definition command")
+def invoke(context: Context) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["get-definition", "foo.py", "1", "0"])
+    context["result"] = result
+
+
+@then("the output includes a symbol line")
+def check(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 0
+    out = result.stdout
+    assert '"symbol"' in out or '"foo"' in out
+
+
+@then("the daemon is not ready")
+def check_not_ready(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 1
+    out = (result.stdout + result.stderr).lower()
+    assert "serena" in out or "missing" in out

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -1,5 +1,6 @@
 import collections.abc as cabc
 import json
+import typing as typ
 from pathlib import Path
 
 import pytest
@@ -36,7 +37,10 @@ def _create_runtime_fixture(
             async def handler(
                 file: str, line: int, char: int
             ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
-                tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
+                tool = typ.cast(
+                    typ.Any,  # noqa: TC006
+                    server.create_serena_tool(SerenaTool.GET_DEFINITION),
+                )
                 for sym in tool.get_definition(file=file, line=line, char=char):
                     yield sym
 

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -1,4 +1,6 @@
 import collections.abc as cabc
+import json
+from pathlib import Path
 
 import pytest
 from pytest_bdd import given, scenarios, then, when
@@ -40,6 +42,27 @@ def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Contex
     return runtime_dir
 
 
+@given("a temporary runtime dir with no symbols", target_fixture="context")
+def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+    class StubTool:
+        def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+            return []
+
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+
+    def setup(dispatcher: RPCDispatcher) -> None:
+        @dispatcher.register("get-definition")
+        async def handler(
+            file: str, line: int, char: int
+        ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
+            tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
+            for sym in tool.get_definition(file=file, line=line, char=char):
+                yield sym
+
+    runtime_dir["register"](setup)
+    return runtime_dir
+
+
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     def raise_error(_: SerenaTool) -> None:
@@ -50,8 +73,19 @@ def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @when("I invoke the get-definition command")
 def invoke(context: Context) -> None:
+    file = Path("foo.py")
+    file.write_text("pass")
     runner = CliRunner()
     result = runner.invoke(app, ["get-definition", "foo.py", "1", "0"])
+    context["result"] = result
+    file.unlink(missing_ok=True)
+
+
+@when("I invoke the get-definition command with a missing file")
+def invoke_missing(context: Context) -> None:
+    Path("nope.py").unlink(missing_ok=True)
+    runner = CliRunner()
+    result = runner.invoke(app, ["get-definition", "nope.py", "1", "0"])
     context["result"] = result
 
 
@@ -59,8 +93,19 @@ def invoke(context: Context) -> None:
 def check(context: Context) -> None:
     result = context["result"]
     assert result.exit_code == 0
-    out = result.stdout
-    assert '"symbol"' in out or '"foo"' in out
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert lines
+    record = json.loads(lines[0])
+    symbol = record.get("symbol", record)
+    assert symbol.get("name") == "foo"
+    assert symbol.get("kind") == "function"
+
+
+@then("no output is produced")
+def check_empty(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
 
 
 @then("the daemon is not ready")
@@ -69,3 +114,11 @@ def check_not_ready(context: Context) -> None:
     assert result.exit_code == 1
     out = (result.stdout + result.stderr).lower()
     assert "serena" in out or "missing" in out
+
+
+@then("the command fails with a missing file error")
+def check_missing_file(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code != 0
+    out = (result.stdout + result.stderr).lower()
+    assert "no such file" in out or "does not exist" in out

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -84,9 +84,16 @@ def onboard_project() -> None:
     _run_rpc("onboard-project")
 
 
+@app.command("get-definition")
+def get_definition(file: Path, line: int, char: int) -> None:
+    """Locate the symbol definition at the given position."""
+
+    params = {"file": str(file), "line": line, "char": char}
+    _run_rpc("get-definition", params)
+
+
 STUBS = [
     "find-symbol",
-    "get-definition",
     "list-references",
     "summarise-symbol",
     "get-call-graph",

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -85,8 +85,29 @@ def onboard_project() -> None:
 
 
 @app.command("get-definition")
-def get_definition(file: Path, line: int, char: int) -> None:
-    """Locate the symbol definition at the given position."""
+def get_definition(
+    file: Path = typer.Argument(  # noqa: B008
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=False,
+    ),
+    line: int = typer.Argument(..., min=0),
+    char: int = typer.Argument(..., min=0),
+) -> None:
+    """Locate the symbol definition at the given 0-indexed position.
+
+    Parameters
+    ----------
+    file : Path
+        Path to the source file.
+    line : int
+        0-indexed line number.
+    char : int
+        0-indexed character offset within the line.
+    """
 
     params = {"file": str(file), "line": line, "char": char}
     _run_rpc("get-definition", params)

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -1,4 +1,5 @@
 import pathlib
+import typing as typ
 
 import pytest
 import typer
@@ -57,14 +58,24 @@ def test_run_rpc_reports_error(
 
 
 @pytest.mark.parametrize(
-    ("cli_command", "rpc_method"),
+    ("cli_command", "rpc_method", "args", "params"),
     [
-        ("project-status", "project-status"),
-        ("onboard-project", "onboard-project"),
+        ("project-status", "project-status", [], None),
+        ("onboard-project", "onboard-project", [], None),
+        (
+            "get-definition",
+            "get-definition",
+            ["foo.py", "1", "2"],
+            {"file": "foo.py", "line": 1, "char": 2},
+        ),
     ],
 )
 def test_cli_commands_use_run_rpc(
-    cli_command: str, rpc_method: str, monkeypatch: pytest.MonkeyPatch
+    cli_command: str,
+    rpc_method: str,
+    args: list[str],
+    params: dict[str, typ.Any] | None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """CLI commands use _run_rpc to contact the daemon."""
     called: dict[str, object] = {}
@@ -76,13 +87,13 @@ def test_cli_commands_use_run_rpc(
     monkeypatch.setattr(cli.anyio, "run", fake_run)
 
     runner = CliRunner()
-    result = runner.invoke(cli.app, [cli_command])
+    result = runner.invoke(cli.app, [cli_command, *args])
 
     assert result.exit_code == 0
     assert called == {
         "func": cli.rpc_call,
         "method": rpc_method,
-        "params": None,
+        "params": params,
     }
 
 

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -1,3 +1,4 @@
+import dataclasses
 import pathlib
 import typing as typ
 
@@ -57,25 +58,29 @@ def test_run_rpc_reports_error(
     assert "Error: boom" in capsys.readouterr().err
 
 
+@dataclasses.dataclass
+class CLITestCase:
+    cli_command: str
+    rpc_method: str
+    args: list[str]
+    params: dict[str, typ.Any] | None
+
+
 @pytest.mark.parametrize(
-    ("cli_command", "rpc_method", "args", "params"),
+    "test_case",
     [
-        ("project-status", "project-status", [], None),
-        ("onboard-project", "onboard-project", [], None),
-        (
+        CLITestCase("project-status", "project-status", [], None),
+        CLITestCase("onboard-project", "onboard-project", [], None),
+        CLITestCase(
             "get-definition",
             "get-definition",
-            ["foo.py", "1", "2"],
-            {"file": "foo.py", "line": 1, "char": 2},
+            [__file__, "1", "2"],
+            {"file": __file__, "line": 1, "char": 2},
         ),
     ],
 )
 def test_cli_commands_use_run_rpc(
-    cli_command: str,
-    rpc_method: str,
-    args: list[str],
-    params: dict[str, typ.Any] | None,
-    monkeypatch: pytest.MonkeyPatch,
+    test_case: CLITestCase, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """CLI commands use _run_rpc to contact the daemon."""
     called: dict[str, object] = {}
@@ -87,14 +92,32 @@ def test_cli_commands_use_run_rpc(
     monkeypatch.setattr(cli.anyio, "run", fake_run)
 
     runner = CliRunner()
-    result = runner.invoke(cli.app, [cli_command, *args])
+    result = runner.invoke(cli.app, [test_case.cli_command, *test_case.args])
 
     assert result.exit_code == 0
     assert called == {
         "func": cli.rpc_call,
-        "method": rpc_method,
-        "params": params,
+        "method": test_case.rpc_method,
+        "params": test_case.params,
     }
+
+
+def test_cli_get_definition_handles_empty_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get-definition exits cleanly when the RPC stream is empty."""
+
+    def fake_run(func, method, params=None):
+        # Simulate RPC call producing no output.
+        return None
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["get-definition", __file__, "1", "2"])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
 
 
 def test_cli_onboard_project_reports_error(

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -120,7 +120,6 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolInstance:
     TypeError
         If ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
     """
-
     wf_tools, prompt_mod = _load_serena_modules()
     name = _resolve_tool_name(tool_attr)
     tool_cls = _validate_and_get_tool_class(wf_tools, name)

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -31,6 +31,7 @@ class SerenaTool(enum.StrEnum):
 
     ONBOARDING = "OnboardingTool"
     LIST_DIAGNOSTICS = "ListDiagnosticsTool"
+    GET_DEFINITION = "GetDefinitionTool"
 
 
 _VALID_TOOL_MEMBER_NAMES = frozenset(SerenaTool.__members__.keys())

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -17,6 +17,7 @@ import msgspec.json as msjson
 
 from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.error import SchemaError
+from weaver_schemas.references import Symbol
 from weaver_schemas.reports import OnboardingReport
 from weaver_schemas.status import ProjectStatus
 
@@ -187,6 +188,23 @@ async def handle_list_diagnostics(
             norm_severity, norm_files, diag_severity, diag_file
         ):
             yield diag
+
+
+@rpc_handler("get-definition")
+async def handle_get_definition(
+    file: str, line: int, char: int
+) -> typ.AsyncIterator[Symbol]:
+    """Yield symbol definitions for the given position."""
+
+    tool = create_serena_tool(SerenaTool.GET_DEFINITION)
+    try:
+        data = await asyncio.to_thread(
+            tool.get_definition, file=file, line=line, char=char
+        )
+    except RuntimeError as exc:
+        raise RuntimeError(f"Definition lookup failed: {exc}") from exc
+    for item in data:
+        yield ms.convert(item, Symbol)
 
 
 async def main(socket_path: Path | None = None) -> None:

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -196,7 +196,10 @@ async def handle_get_definition(
 ) -> typ.AsyncIterator[Symbol]:
     """Yield symbol definitions for the given position."""
 
-    tool = create_serena_tool(SerenaTool.GET_DEFINITION)
+    tool = typ.cast(
+        typ.Any,  # noqa: TC006
+        create_serena_tool(SerenaTool.GET_DEFINITION),
+    )
     try:
         data = await asyncio.to_thread(
             tool.get_definition, file=file, line=line, char=char

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -1,0 +1,45 @@
+import builtins
+
+import pytest
+
+from weaver_schemas.primitives import Location, Position, Range
+from weaver_schemas.references import Symbol
+from weaverd import server
+from weaverd.serena_tools import SerenaTool
+
+
+class StubTool:
+    def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+        loc = Location(
+            file=file,
+            range=Range(start=Position(line, char), end=Position(line, char + 1)),
+        )
+        return [Symbol(name="foo", kind="function", location=loc)]
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+    results = server.handle_get_definition("foo.py", 1, 0)
+    sym = await builtins.anext(results)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert sym.name == "foo"
+
+
+@pytest.mark.anyio
+async def test_handle_get_definition_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_error(_: SerenaTool) -> None:
+        raise RuntimeError("serena-agent not found")
+
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+
+    with pytest.raises(RuntimeError, match="serena-agent not found"):
+        await builtins.anext(server.handle_get_definition("foo.py", 1, 0))

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -32,6 +32,21 @@ async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
     assert sym.name == "foo"
 
 
+class EmptyTool:
+    def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+        return []
+
+
+@pytest.mark.anyio
+async def test_handle_get_definition_no_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: EmptyTool())
+    results = server.handle_get_definition("foo.py", 1, 0)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+
+
 @pytest.mark.anyio
 async def test_handle_get_definition_missing_dependency(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add get-definition CLI command and daemon handler
- document design of get-definition and update roadmap
- add unit and behaviour tests for get-definition

## Testing
- `make lint`
- `make test`
- `make typecheck`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x --bun @mermaid-js/mermaid-cli ... libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689b0555b3dc8322bc5dabd48b5d3505

## Summary by Sourcery

Implement the get-definition command end-to-end by adding a new CLI entry, daemon handler, tool integration, documentation updates, and tests

New Features:
- Introduce get-definition CLI command to request symbol definitions
- Add get-definition RPC handler in the daemon using Serena's GetDefinitionTool
- Extend SerenaTool enum with GET_DEFINITION entry

Enhancements:
- Document the design of get-definition in the design spec and mark it as completed in the roadmap

Documentation:
- Update weaver-design.md to describe get-definition flow
- Update roadmap.md to reflect completion of get-definition

Tests:
- Add unit tests for handle_get_definition and its missing-dependency error path
- Extend CLI tests to cover the get-definition command invocation
- Add BDD feature tests for get-definition scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a get-definition command that locates symbol definitions and streams symbol results; handles empty responses and reports missing-agent errors.

- **Documentation**
  - Marked get-definition complete in the roadmap and expanded design notes to describe streaming diagnostics, onboarding error messaging, and the get-definition workflow.

- **Tests**
  - Added unit and end-to-end tests covering successful retrieval, empty streams, missing dependency, and missing-file error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->