### PR TITLE
Cast Serena tools to Protocols in server handlers

### DIFF
--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -23,6 +23,15 @@ from weaver_schemas.status import ProjectStatus
 from .rpc import Handler, RPCDispatcher
 from .serena_tools import SerenaTool, create_serena_tool
 
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+
+    class _OnboardingTool(typ.Protocol):
+        def apply(self) -> str: ...
+
+    class _DiagnosticsTool(typ.Protocol):
+        def list_diagnostics(self) -> list[typ.Any]: ...
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -117,9 +126,11 @@ async def handle_project_status() -> ProjectStatus:
 @rpc_handler("onboard-project")
 async def handle_onboard_project() -> OnboardingReport:
     """Run the onboarding tool and return its report."""
-    tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.ONBOARDING))  # noqa: TC006
     try:
+        tool = typ.cast("_OnboardingTool", create_serena_tool(SerenaTool.ONBOARDING))
         details = await asyncio.to_thread(tool.apply)
+    except (asyncio.CancelledError, KeyboardInterrupt):  # propagate cancels
+        raise
     except Exception as exc:  # pragma: no cover - unexpected failures
         raise RuntimeError(f"Onboarding failed: {exc}") from exc
     return OnboardingReport(details=details)
@@ -174,11 +185,14 @@ async def handle_list_diagnostics(
 
     # Prepare filters for case- and path-insensitive comparison
     norm_severity, norm_files = _normalize_filters(severity, files)
-
-    tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.LIST_DIAGNOSTICS))  # noqa: TC006
     try:
+        tool = typ.cast(
+            "_DiagnosticsTool", create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
+        )
         data = await asyncio.to_thread(tool.list_diagnostics)
-    except RuntimeError as exc:
+    except (asyncio.CancelledError, KeyboardInterrupt):  # propagate cancels
+        raise
+    except Exception as exc:
         raise RuntimeError(f"Diagnostics failed: {exc}") from exc
     for item in data:
         diag = ms.convert(item, Diagnostic)

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -29,7 +29,9 @@ if typ.TYPE_CHECKING:  # pragma: no cover - typing only
         def apply(self) -> str: ...
 
     class _DiagnosticsTool(typ.Protocol):
-        def list_diagnostics(self) -> list[typ.Any]: ...
+        def list_diagnostics(
+            self,
+        ) -> typ.Iterable[Diagnostic | typ.Mapping[str, typ.Any]]: ...
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- wrap Serena tool creation in onboard and diagnostics handlers
- propagate cancellation and wrap unexpected errors consistently

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e0c6e1e148322a1ed56235a886cbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding and diagnostics requests now respect cancellations promptly, improving responsiveness and preventing stalled operations.

* **Refactor**
  * Clarified error-handling paths to cleanly propagate cancellations while preserving existing behavior and outputs.

* **Chores**
  * Tightened internal type constraints for tool integrations to enhance reliability and maintainability.
  * No changes to public APIs or user-facing behavior beyond improved cancellation responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->