### PR TITLE
Implement get-definition command

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,7 @@ This phase focuses on wrapping Serena's tool capabilities.*
 
 - [ ] **Implement Orient Commands:**
 
-  - [ ] `get-definition`: Implement the handler to call the definition-fetching
+  - [x] `get-definition`: Implement the handler to call the definition-fetching
     method in Serena's tools.
 
   - [ ] `list-references`: Implement the handler to call the reference-finding

--- a/features/get_definition.feature
+++ b/features/get_definition.feature
@@ -1,0 +1,5 @@
+Feature: get definition command
+  Scenario: daemon auto-start
+    Given a temporary runtime dir
+    When I invoke the get-definition command for file "foo.py" line 1 char 0
+    Then the output includes a symbol line

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -1,0 +1,64 @@
+import typing as typ
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+from typer.testing import CliRunner
+
+from features.types import Context
+from weaver.cli import app
+from weaver_schemas.primitives import Location, Position, Range
+from weaver_schemas.references import Symbol
+from weaverd import server
+from weaverd.rpc import RPCDispatcher
+from weaverd.serena_tools import SerenaTool
+
+scenarios("../get_definition.feature")
+
+
+@given("a temporary runtime dir", target_fixture="context")
+def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+    class StubTool:
+        def get_definition(self, file: str, line: int, char: int) -> list[Symbol]:
+            loc = Location(
+                file=file,
+                range=Range(start=Position(line, char), end=Position(line, char + 1)),
+            )
+            return [Symbol(name="spam", kind="function", location=loc)]
+
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+
+    def setup(dispatcher: RPCDispatcher) -> None:
+        @dispatcher.register("get-definition")
+        async def handler(
+            file: str, line: int, char: int
+        ) -> typ.AsyncIterator[Symbol]:  # pragma: no cover - stub
+            tool = typ.cast(
+                typ.Any,  # noqa: TC006
+                server.create_serena_tool(SerenaTool.GET_DEFINITION),
+            )
+            for sym in tool.get_definition(file=file, line=line, char=char):
+                yield sym
+
+    runtime_dir["register"](setup)
+    return runtime_dir
+
+
+_INVOKE_RE = (
+    r"I invoke the get-definition command for file "
+    r'"(?P<file>[^"]+)" line (?P<line>\d+) char (?P<char>\d+)'
+)
+
+
+@when(parsers.re(_INVOKE_RE))
+def invoke(context: Context, file: str, line: str, char: str) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["get-definition", file, line, char])
+    context["result"] = result
+
+
+@then("the output includes a symbol line")
+def check(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 0
+    out = result.stdout.lower()
+    assert "symbol" in out or "spam" in out

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -84,9 +84,15 @@ def onboard_project() -> None:
     _run_rpc("onboard-project")
 
 
+@app.command("get-definition")
+def get_definition(file: Path, line: int, char: int) -> None:
+    """Fetch the definition at the given location."""
+    params = {"file": str(file), "line": line, "char": char}
+    _run_rpc("get-definition", params)
+
+
 STUBS = [
     "find-symbol",
-    "get-definition",
     "list-references",
     "summarise-symbol",
     "get-call-graph",

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -31,6 +31,7 @@ class SerenaTool(enum.StrEnum):
 
     ONBOARDING = "OnboardingTool"
     LIST_DIAGNOSTICS = "ListDiagnosticsTool"
+    GET_DEFINITION = "GetDefinitionTool"
 
 
 _VALID_TOOL_MEMBER_NAMES = frozenset(SerenaTool.__members__.keys())

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -17,6 +17,7 @@ import msgspec.json as msjson
 
 from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.error import SchemaError
+from weaver_schemas.references import Symbol
 from weaver_schemas.reports import OnboardingReport
 from weaver_schemas.status import ProjectStatus
 
@@ -123,6 +124,23 @@ async def handle_onboard_project() -> OnboardingReport:
     except Exception as exc:  # pragma: no cover - unexpected failures
         raise RuntimeError(f"Onboarding failed: {exc}") from exc
     return OnboardingReport(details=details)
+
+
+@rpc_handler("get-definition")
+async def handle_get_definition(
+    file: str, line: int, char: int
+) -> typ.AsyncIterator[Symbol]:
+    """Yield symbol definitions for the given location."""
+
+    tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.GET_DEFINITION))  # noqa: TC006
+    try:
+        data = await asyncio.to_thread(
+            tool.get_definition, file=file, line=line, char=char
+        )
+    except RuntimeError as exc:
+        raise RuntimeError(f"Definition lookup failed: {exc}") from exc
+    for item in data:
+        yield ms.convert(item, Symbol)
 
 
 def _normalize_filters(

--- a/weaverd/unittests/test_get_definition_server.py
+++ b/weaverd/unittests/test_get_definition_server.py
@@ -1,0 +1,31 @@
+import builtins
+
+import pytest
+
+from weaver_schemas.primitives import Location, Position, Range
+from weaver_schemas.references import Symbol
+from weaverd import server
+
+
+class Tool:
+    def get_definition(self, file: str, line: int, char: int) -> list[Symbol]:
+        loc = Location(
+            file=file,
+            range=Range(start=Position(line, char), end=Position(line, char + 1)),
+        )
+        return [Symbol(name="spam", kind="function", location=loc)]
+
+
+@pytest.mark.anyio
+async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: Tool())
+    results = server.handle_get_definition("foo.py", line=1, char=0)
+    sym = await builtins.anext(results)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert sym.name == "spam"
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"


### PR DESCRIPTION
## Summary
- add `GET_DEFINITION` tool and RPC handler
- expose `get-definition` CLI command
- cover new command with tests and update roadmap

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e527040108322bdd24bdb2cb47083

## Summary by Sourcery

Implement the get-definition command to retrieve symbol definitions via the Serena tool across the server and CLI.

New Features:
- Introduce a GET_DEFINITION tool enum member and RPC handler to fetch definitions in the server
- Expose a get-definition command in the CLI for users to invoke definition lookups

Documentation:
- Mark the get-definition command as implemented in the project roadmap

Tests:
- Add unit tests for the handle_get_definition RPC handler
- Add BDD feature tests for the get-definition CLI command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “get-definition” CLI command to retrieve symbol definitions for a given file position.
  - Introduced a corresponding RPC endpoint to stream definition results.

- Tests
  - Added BDD feature and step tests covering the “get-definition” command and daemon auto-start behavior.
  - Added unit tests validating server handling and output for definition requests.

- Documentation
  - Updated roadmap to reflect implementation status of the definition-fetching capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->