### PR TITLE
Cast serena tools for definition lookup

### DIFF
--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -1,5 +1,6 @@
 import collections.abc as cabc
 import json
+import typing as typ
 from pathlib import Path
 
 import pytest
@@ -36,7 +37,10 @@ def _create_runtime_fixture(
             async def handler(
                 file: str, line: int, char: int
             ) -> cabc.AsyncIterator[Symbol]:  # pragma: no cover - stub
-                tool = server.create_serena_tool(SerenaTool.GET_DEFINITION)
+                tool = typ.cast(
+                    typ.Any,  # noqa: TC006
+                    server.create_serena_tool(SerenaTool.GET_DEFINITION),
+                )
                 for sym in tool.get_definition(file=file, line=line, char=char):
                     yield sym
 

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -196,7 +196,10 @@ async def handle_get_definition(
 ) -> typ.AsyncIterator[Symbol]:
     """Yield symbol definitions for the given position."""
 
-    tool = create_serena_tool(SerenaTool.GET_DEFINITION)
+    tool = typ.cast(
+        typ.Any,  # noqa: TC006
+        create_serena_tool(SerenaTool.GET_DEFINITION),
+    )
     try:
         data = await asyncio.to_thread(
             tool.get_definition, file=file, line=line, char=char


### PR DESCRIPTION
## Summary
- cast Serena get-definition tool to `Any` in server handler
- cast stubbed Serena tool in get-definition tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e855f71c8832293ce9270b71d204d

## Summary by Sourcery

Cast the Serena get-definition tool to Any in both the server handler and test code to address typing issues.

Enhancements:
- Cast the Serena get-definition tool to Any in the server handler to satisfy type checks
- Add a cast to Any for the stubbed Serena tool in get-definition tests