### PR TITLE
Clarify get-definition indexing and expand tests

### DIFF
--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -170,10 +170,10 @@ the `rss_mb` field. The response reports the daemon process ID, resident memory
 | list-memories      | Stream previously stored memory snippets.                                                 |
 
 The `get-definition` handler invokes Serena's `GetDefinitionTool`. The daemon
-passes the file and 0-indexed line/character (in UTF-16 code units) to the tool
-on a worker thread and streams each resulting `Symbol` back to the client. This
-mirrors the LSP `textDocument/definition` semantics while remaining
-JSONL-friendly and non-blocking.
+passes the file and a 0-indexed `Position` (line and character in UTF-16 code
+units) to the tool on a worker thread and streams each resulting `Symbol` back
+to the client. This mirrors the LSP `textDocument/definition` semantics while
+remaining JSONL-friendly and non-blocking.
 
 ### 2.3 Decide
 
@@ -288,10 +288,10 @@ user-friendly `RuntimeError` if `serena-agent` is missing.
 
 `list-diagnostics` relies on Serena's `ListDiagnosticsTool`. The handler
 initialises the tool with a new `SerenaPromptFactory`, invokes
-`list_diagnostics` in a background thread, and yields each `Diagnostic` model
-instance through the RPC stream after converting tool outputs with
-`msgspec.convert`. Optional `severity` and `files` parameters filter the
-diagnostics while streaming, avoiding large in-memory collections.
+`list_diagnostics` on a background thread and streams each `Diagnostic` model
+instance after converting tool outputs with `msgspec.convert`. Optional
+`severity` and `files` parameters filter the diagnostics while streaming,
+avoiding large in-memory collections.
 
 `weaverd` exposes a lightweight RPC interface over a UNIX domain socket. A
 custom `RPCDispatcher` maps method names to coroutine handlers and uses

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -170,9 +170,10 @@ the `rss_mb` field. The response reports the daemon process ID, resident memory
 | list-memories      | Stream previously stored memory snippets.                                                 |
 
 The `get-definition` handler invokes Serena's `GetDefinitionTool`. The daemon
-passes the file and 0-indexed cursor position to the tool on a worker thread
-and streams each resulting `Symbol` structure back to the client. This mirrors
-the LSP definition request while remaining JSONL-friendly and non-blocking.
+passes the file and a 0-indexed `Position` (line and character in UTF-16 code
+units) to the tool on a worker thread and streams each resulting `Symbol` back
+to the client. This mirrors the LSP `textDocument/definition` semantics while
+remaining JSONL-friendly and non-blocking.
 
 ### 2.3 Decide
 
@@ -283,12 +284,12 @@ dependency.
 
 Both onboarding and diagnostics tools share common import logic. A helper in
 the daemon loads the requested Serena tool and prompt factory, raising a
-user-friendly ``RuntimeError`` if ``serena-agent`` is missing.
+user-friendly `RuntimeError` if `serena-agent` is missing.
 
 `list-diagnostics` relies on Serena's `ListDiagnosticsTool`. The handler
 initialises the tool with a new `SerenaPromptFactory`, invokes
-`list_diagnostics` in a background thread and yields each dictionary through
-the RPC stream after converting it to the internal `Diagnostic` model using
+`list_diagnostics` in a background thread, and yields each `Diagnostic` model
+instance through the RPC stream after converting tool outputs with
 `msgspec.convert`. Optional `severity` and `files` parameters filter the
 diagnostics while streaming, avoiding large in-memory collections.
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -170,10 +170,10 @@ the `rss_mb` field. The response reports the daemon process ID, resident memory
 | list-memories      | Stream previously stored memory snippets.                                                 |
 
 The `get-definition` handler invokes Serena's `GetDefinitionTool`. The daemon
-passes the file and a 0-indexed `Position` (line and character in UTF-16 code
-units) to the tool on a worker thread and streams each resulting `Symbol` back
-to the client. This mirrors the LSP `textDocument/definition` semantics while
-remaining JSONL-friendly and non-blocking.
+passes the file and 0-indexed line/character (in UTF-16 code units) to the tool
+on a worker thread and streams each resulting `Symbol` back to the client. This
+mirrors the LSP `textDocument/definition` semantics while remaining
+JSONL-friendly and non-blocking.
 
 ### 2.3 Decide
 

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -84,18 +84,15 @@ def invoke(context: Context, tmp_path: Path) -> None:
     file = tmp_path / "foo.py"
     file.write_text("pass")
     runner = CliRunner()
-    try:
-        result = runner.invoke(app, ["get-definition", str(file), "1", "0"])
-        context["result"] = result
-    finally:
-        file.unlink(missing_ok=True)
+    result = runner.invoke(app, ["get-definition", str(file), "1", "0"])
+    context["result"] = result
 
 
 @when("I invoke the get-definition command with a missing file")
-def invoke_missing(context: Context) -> None:
-    Path("nope.py").unlink(missing_ok=True)
+def invoke_missing(context: Context, tmp_path: Path) -> None:
+    file = tmp_path / "nope.py"  # intentionally not created
     runner = CliRunner()
-    result = runner.invoke(app, ["get-definition", "nope.py", "1", "0"])
+    result = runner.invoke(app, ["get-definition", str(file), "1", "0"])
     context["result"] = result
 
 

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -84,7 +84,7 @@ def invoke(context: Context, tmp_path: Path) -> None:
     file = tmp_path / "foo.py"
     file.write_text("pass")
     runner = CliRunner()
-    result = runner.invoke(app, ["get-definition", str(file), "1", "0"])
+    result = runner.invoke(app, ["get-definition", str(file), "0", "0"])
     context["result"] = result
 
 
@@ -92,7 +92,7 @@ def invoke(context: Context, tmp_path: Path) -> None:
 def invoke_missing(context: Context, tmp_path: Path) -> None:
     file = tmp_path / "nope.py"  # intentionally not created
     runner = CliRunner()
-    result = runner.invoke(app, ["get-definition", str(file), "1", "0"])
+    result = runner.invoke(app, ["get-definition", str(file), "0", "0"])
     context["result"] = result
 
 

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -194,10 +194,12 @@ async def handle_list_diagnostics(
 async def handle_get_definition(
     file: str, line: int, char: int
 ) -> typ.AsyncIterator[Symbol]:
-    """Yield symbol definitions for the given position."""
+    """Yield symbol definitions for a 0-indexed UTF-16 line/character."""
 
     if line < 0 or char < 0:  # basic input validation
-        raise ValueError("line and char must be non-negative")
+        raise ValueError(
+            "line and character must be non-negative (0-indexed, UTF-16 code units)"
+        )
 
     tool = typ.cast(
         typ.Any,  # noqa: TC006

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -196,6 +196,9 @@ async def handle_get_definition(
 ) -> typ.AsyncIterator[Symbol]:
     """Yield symbol definitions for the given position."""
 
+    if line < 0 or char < 0:  # basic input validation
+        raise ValueError("line and char must be non-negative")
+
     tool = typ.cast(
         typ.Any,  # noqa: TC006
         create_serena_tool(SerenaTool.GET_DEFINITION),

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -1,4 +1,4 @@
-import builtins
+from builtins import anext  # noqa: A004
 
 import pytest
 
@@ -26,10 +26,14 @@ def anyio_backend() -> str:
 async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
     results = server.handle_get_definition("foo.py", 1, 0)
-    sym = await builtins.anext(results)
+    sym = await anext(results)
     with pytest.raises(StopAsyncIteration):
-        await builtins.anext(results)
+        await anext(results)
     assert sym.name == "foo"
+    assert sym.kind == "function"
+    assert sym.location.file == "foo.py"
+    assert sym.location.range.start.line == 1
+    assert sym.location.range.start.character == 0
 
 
 class EmptyTool:
@@ -44,7 +48,7 @@ async def test_handle_get_definition_no_symbols(
     monkeypatch.setattr(server, "create_serena_tool", lambda _: EmptyTool())
     results = server.handle_get_definition("foo.py", 1, 0)
     with pytest.raises(StopAsyncIteration):
-        await builtins.anext(results)
+        await anext(results)
 
 
 @pytest.mark.anyio
@@ -57,4 +61,4 @@ async def test_handle_get_definition_missing_dependency(
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
     with pytest.raises(RuntimeError, match="serena-agent not found"):
-        await builtins.anext(server.handle_get_definition("foo.py", 1, 0))
+        await anext(server.handle_get_definition("foo.py", 1, 0))

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -34,6 +34,8 @@ async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
     assert sym.location.file == "foo.py"
     assert sym.location.range.start.line == 1
     assert sym.location.range.start.character == 0
+    assert sym.location.range.end.line == 1
+    assert sym.location.range.end.character == 1
 
 
 class EmptyTool:

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -17,6 +17,32 @@ class StubTool:
         return [Symbol(name="foo", kind="function", location=loc)]
 
 
+class EmptyTool:
+    def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+        return []
+
+
+class MultiTool:
+    def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+        loc1 = Location(
+            file=file,
+            range=Range(start=Position(line, char), end=Position(line, char + 1)),
+        )
+        loc2 = Location(
+            file=file,
+            range=Range(start=Position(line, char + 2), end=Position(line, char + 3)),
+        )
+        return [
+            Symbol(name="foo", kind="function", location=loc1),
+            Symbol(name="bar", kind="class", location=loc2),
+        ]
+
+
+class DummyTool:
+    def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
+        return []
+
+
 @pytest.fixture()
 def anyio_backend() -> str:
     return "asyncio"
@@ -38,11 +64,6 @@ async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
     assert sym.location.range.end.character == 1
 
 
-class EmptyTool:
-    def get_definition(self, *, file: str, line: int, char: int) -> list[Symbol]:
-        return []
-
-
 @pytest.mark.anyio
 async def test_handle_get_definition_no_symbols(
     monkeypatch: pytest.MonkeyPatch,
@@ -51,6 +72,19 @@ async def test_handle_get_definition_no_symbols(
     results = server.handle_get_definition("foo.py", 1, 0)
     with pytest.raises(StopAsyncIteration):
         await anext(results)
+
+
+@pytest.mark.anyio
+async def test_handle_get_definition_multiple_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: MultiTool())
+    results = server.handle_get_definition("foo.py", 1, 0)
+    first = await anext(results)
+    second = await anext(results)
+    with pytest.raises(StopAsyncIteration):
+        await anext(results)
+    assert [first.name, second.name] == ["foo", "bar"]
 
 
 @pytest.mark.anyio
@@ -64,3 +98,16 @@ async def test_handle_get_definition_missing_dependency(
 
     with pytest.raises(RuntimeError, match="serena-agent not found"):
         await anext(server.handle_get_definition("foo.py", 1, 0))
+
+
+@pytest.mark.anyio
+async def test_handle_get_definition_invalid_position(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: DummyTool())
+    with pytest.raises(ValueError):
+        await anext(server.handle_get_definition("foo.py", -1, 0))
+    with pytest.raises(ValueError):
+        await anext(server.handle_get_definition("foo.py", 1, -5))
+    with pytest.raises(ValueError):
+        await anext(server.handle_get_definition("foo.py", -2, -3))

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -1,4 +1,5 @@
 import builtins
+from dataclasses import dataclass  # noqa: ICN003 -- simpler decorator usage
 
 import pytest
 
@@ -53,12 +54,19 @@ class DummyTool:
         return []
 
 
+@dataclass
+class FilePosition:
+    file: str
+    line: int
+    char: int
+
+
 async def _setup_and_call_get_definition(
-    monkeypatch: pytest.MonkeyPatch, tool_class, file: str, line: int, char: int
+    monkeypatch: pytest.MonkeyPatch, tool_class, position: FilePosition
 ):
     """Helper to setup mock and call handle_get_definition."""
     monkeypatch.setattr(server, "create_serena_tool", lambda _: tool_class())
-    return server.handle_get_definition(file, line, char)
+    return server.handle_get_definition(position.file, position.line, position.char)
 
 
 async def _collect_symbols_from_results(results, expected_count: int) -> list[Symbol]:
@@ -77,15 +85,15 @@ async def _collect_symbols_from_results(results, expected_count: int) -> list[Sy
     return symbols
 
 
-def _assert_symbol_location(
-    symbol: Symbol, file: str, line: int, start_char: int, end_char: int
-) -> None:
+def _assert_symbol_location(symbol: Symbol, expected_location: Location) -> None:
     """Helper to assert symbol location properties."""
-    assert symbol.location.file == file
-    assert symbol.location.range.start.line == line
-    assert symbol.location.range.start.character == start_char
-    assert symbol.location.range.end.line == line
-    assert symbol.location.range.end.character == end_char
+    assert symbol.location.file == expected_location.file
+    assert symbol.location.range.start.line == expected_location.range.start.line
+    assert (
+        symbol.location.range.start.character == expected_location.range.start.character
+    )
+    assert symbol.location.range.end.line == expected_location.range.end.line
+    assert symbol.location.range.end.character == expected_location.range.end.character
 
 
 @pytest.fixture()
@@ -96,12 +104,21 @@ def anyio_backend() -> str:
 @pytest.mark.anyio
 async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
     results = await _setup_and_call_get_definition(
-        monkeypatch, StubTool, "foo.py", 1, 0
+        monkeypatch, StubTool, FilePosition("foo.py", 1, 0)
     )
     sym = (await _collect_symbols_from_results(results, 1))[0]
     assert sym.name == "foo"
     assert sym.kind == "function"
-    _assert_symbol_location(sym, "foo.py", 1, 0, 1)
+    _assert_symbol_location(
+        sym,
+        Location(
+            file="foo.py",
+            range=Range(
+                start=Position(1, 0),
+                end=Position(1, 1),
+            ),
+        ),
+    )
 
 
 @pytest.mark.anyio
@@ -109,7 +126,7 @@ async def test_handle_get_definition_no_symbols(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     results = await _setup_and_call_get_definition(
-        monkeypatch, EmptyTool, "foo.py", 1, 0
+        monkeypatch, EmptyTool, FilePosition("foo.py", 1, 0)
     )
     await _collect_symbols_from_results(results, 0)
 
@@ -119,13 +136,31 @@ async def test_handle_get_definition_multiple_symbols(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     results = await _setup_and_call_get_definition(
-        monkeypatch, MultiTool, "foo.py", 1, 0
+        monkeypatch, MultiTool, FilePosition("foo.py", 1, 0)
     )
     first, second = await _collect_symbols_from_results(results, 2)
     assert [first.name, second.name] == ["foo", "bar"]
     assert [first.kind, second.kind] == ["function", "class"]
-    _assert_symbol_location(first, "foo.py", 1, 0, 1)
-    _assert_symbol_location(second, "foo.py", 1, 2, 3)
+    _assert_symbol_location(
+        first,
+        Location(
+            file="foo.py",
+            range=Range(
+                start=Position(1, 0),
+                end=Position(1, 1),
+            ),
+        ),
+    )
+    _assert_symbol_location(
+        second,
+        Location(
+            file="foo.py",
+            range=Range(
+                start=Position(1, 2),
+                end=Position(1, 3),
+            ),
+        ),
+    )
 
 
 @pytest.mark.anyio

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -1,4 +1,4 @@
-from builtins import anext  # noqa: A004
+import builtins
 
 import pytest
 
@@ -6,6 +6,16 @@ from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Symbol
 from weaverd import server
 from weaverd.serena_tools import SerenaTool
+
+try:
+    _anext = builtins.anext  # type: ignore[attr-defined]
+except AttributeError:  # Python < 3.10
+
+    async def _anext(it):
+        return await it.__anext__()
+
+
+globals()["anext"] = _anext
 
 
 class StubTool:
@@ -85,6 +95,10 @@ async def test_handle_get_definition_multiple_symbols(
     with pytest.raises(StopAsyncIteration):
         await anext(results)
     assert [first.name, second.name] == ["foo", "bar"]
+    assert [first.kind, second.kind] == ["function", "class"]
+    assert first.location.file == "foo.py"
+    assert first.location.range.start.character == 0
+    assert second.location.range.start.character == 2
 
 
 @pytest.mark.anyio
@@ -101,13 +115,10 @@ async def test_handle_get_definition_missing_dependency(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("line,char", [(-1, 0), (1, -5), (-2, -3)])
 async def test_handle_get_definition_invalid_position(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, line: int, char: int
 ) -> None:
     monkeypatch.setattr(server, "create_serena_tool", lambda _: DummyTool())
     with pytest.raises(ValueError):
-        await anext(server.handle_get_definition("foo.py", -1, 0))
-    with pytest.raises(ValueError):
-        await anext(server.handle_get_definition("foo.py", 1, -5))
-    with pytest.raises(ValueError):
-        await anext(server.handle_get_definition("foo.py", -2, -3))
+        await anext(server.handle_get_definition("foo.py", line, char))

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -53,6 +53,41 @@ class DummyTool:
         return []
 
 
+async def _setup_and_call_get_definition(
+    monkeypatch: pytest.MonkeyPatch, tool_class, file: str, line: int, char: int
+):
+    """Helper to setup mock and call handle_get_definition."""
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: tool_class())
+    return server.handle_get_definition(file, line, char)
+
+
+async def _collect_symbols_from_results(results, expected_count: int) -> list[Symbol]:
+    """Helper to collect symbols from async iterator and verify count."""
+    symbols: list[Symbol] = []
+    try:
+        for _ in range(expected_count):
+            symbols.append(await anext(results))
+        # Verify no more symbols remain
+        with pytest.raises(StopAsyncIteration):
+            await anext(results)
+    except StopAsyncIteration:
+        if len(symbols) != expected_count:
+            pytest.fail(f"Expected {expected_count} symbols, got {len(symbols)}")
+        raise
+    return symbols
+
+
+def _assert_symbol_location(
+    symbol: Symbol, file: str, line: int, start_char: int, end_char: int
+) -> None:
+    """Helper to assert symbol location properties."""
+    assert symbol.location.file == file
+    assert symbol.location.range.start.line == line
+    assert symbol.location.range.start.character == start_char
+    assert symbol.location.range.end.line == line
+    assert symbol.location.range.end.character == end_char
+
+
 @pytest.fixture()
 def anyio_backend() -> str:
     return "asyncio"
@@ -60,45 +95,37 @@ def anyio_backend() -> str:
 
 @pytest.mark.anyio
 async def test_handle_get_definition(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
-    results = server.handle_get_definition("foo.py", 1, 0)
-    sym = await anext(results)
-    with pytest.raises(StopAsyncIteration):
-        await anext(results)
+    results = await _setup_and_call_get_definition(
+        monkeypatch, StubTool, "foo.py", 1, 0
+    )
+    sym = (await _collect_symbols_from_results(results, 1))[0]
     assert sym.name == "foo"
     assert sym.kind == "function"
-    assert sym.location.file == "foo.py"
-    assert sym.location.range.start.line == 1
-    assert sym.location.range.start.character == 0
-    assert sym.location.range.end.line == 1
-    assert sym.location.range.end.character == 1
+    _assert_symbol_location(sym, "foo.py", 1, 0, 1)
 
 
 @pytest.mark.anyio
 async def test_handle_get_definition_no_symbols(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(server, "create_serena_tool", lambda _: EmptyTool())
-    results = server.handle_get_definition("foo.py", 1, 0)
-    with pytest.raises(StopAsyncIteration):
-        await anext(results)
+    results = await _setup_and_call_get_definition(
+        monkeypatch, EmptyTool, "foo.py", 1, 0
+    )
+    await _collect_symbols_from_results(results, 0)
 
 
 @pytest.mark.anyio
 async def test_handle_get_definition_multiple_symbols(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(server, "create_serena_tool", lambda _: MultiTool())
-    results = server.handle_get_definition("foo.py", 1, 0)
-    first = await anext(results)
-    second = await anext(results)
-    with pytest.raises(StopAsyncIteration):
-        await anext(results)
+    results = await _setup_and_call_get_definition(
+        monkeypatch, MultiTool, "foo.py", 1, 0
+    )
+    first, second = await _collect_symbols_from_results(results, 2)
     assert [first.name, second.name] == ["foo", "bar"]
     assert [first.kind, second.kind] == ["function", "class"]
-    assert first.location.file == "foo.py"
-    assert first.location.range.start.character == 0
-    assert second.location.range.start.character == 2
+    _assert_symbol_location(first, "foo.py", 1, 0, 1)
+    _assert_symbol_location(second, "foo.py", 1, 2, 3)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Clarify that get-definition uses UTF-16 positions and align terminology with LSP
- Use single-backticks for inline code and describe `list-diagnostics` stream as `Diagnostic` models
- Strengthen definition handler unit tests and simplify CLI steps

## Testing
- `make lint`
- `make check-fmt`
- `make typecheck`
- `make markdownlint`
- `make nixie`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e891d2ff08322850defb7ded494e9

## Summary by Sourcery

Clarify get-definition indexing to UTF-16 positions and align terminology with LSP in documentation, describe list-diagnostics as streaming Diagnostic models, and enhance and simplify get-definition tests with additional assertions and streamlined CLI setup.

Documentation:
- Clarify that get-definition uses UTF-16 code-unit positions and align its description with LSP textDocument/definition semantics using single backticks
- Document that list-diagnostics streams produce internal Diagnostic model instances with optional filtering

Tests:
- Streamline CLI tests for get-definition using tmp_path and remove unnecessary cleanup constructs
- Strengthen unit tests for handle_get_definition by using anext, adding assertions for symbol kind and location, and preserving StopAsyncIteration checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified get-definition now uses a 0-indexed Position (line and UTF-16 character) and aligned RPC/docs with msgspec-backed validation, error semantics, and socket defaults; minor editorial formatting tweaks.

* **Bug Fixes**
  * Added validation to reject negative position inputs with a clear error; diagnostics streaming now emits typed Diagnostic instances.

* **Tests**
  * Improved isolation with tmp paths, simplified async iteration compatibility, and added coverage for multiple-symbol and invalid-position cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->