### PR TITLE
Add list-references orient command

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,7 +104,7 @@ This phase focuses on wrapping Serena's tool capabilities.*
   - [x] `get-definition`: Implement the handler to call the definition-fetching
     method in Serena's tools.
 
-  - [ ] `list-references`: Implement the handler to call the reference-finding
+  - [x] `list-references`: Implement the handler to call the reference-finding
     method in Serena's tools.
 
   - [ ] `find-symbol`: Implement the handler to call the workspace symbol

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -174,6 +174,11 @@ passes the file and 0-indexed cursor position to the tool on a worker thread
 and streams each resulting `Symbol` structure back to the client. This mirrors
 the LSP definition request while remaining JSONL-friendly and non-blocking.
 
+The `list-references` handler wraps Serena's `ListReferencesTool`. It forwards
+the file path, cursor position, and an `include_definition` flag mirroring the
+LSP's `includeDeclaration` parameter. The tool's results are streamed back as
+`Reference` records, optionally including the symbol's defining location.
+
 ### 2.3 Decide
 
 | Command             | Synopsis                                                                                |

--- a/features/list_references.feature
+++ b/features/list_references.feature
@@ -1,0 +1,26 @@
+Feature: list references command
+  Scenario: daemon auto-start
+    Given a temporary runtime dir
+    When I invoke the list-references command
+    Then the output includes a reference line
+
+  Scenario: no references at position
+    Given a temporary runtime dir with no references
+    When I invoke the list-references command
+    Then no output is produced
+
+  Scenario: include definition
+    Given a temporary runtime dir
+    When I invoke the list-references command with include-definition
+    Then the output includes a definition reference
+
+  Scenario: missing serena-agent dependency
+    Given a temporary runtime dir
+    And serena-agent is missing
+    When I invoke the list-references command
+    Then the daemon is not ready
+
+  Scenario: file not found
+    Given a temporary runtime dir
+    When I invoke the list-references command with a missing file
+    Then the command fails with a missing file error

--- a/features/steps/__init__.py
+++ b/features/steps/__init__.py
@@ -1,0 +1,1 @@
+"""BDD step helpers."""

--- a/features/steps/helpers.py
+++ b/features/steps/helpers.py
@@ -1,0 +1,16 @@
+"""Shared helpers for BDD step implementations."""
+
+from features.types import Context
+from weaverd import server
+from weaverd.rpc import RPCDispatcher
+
+
+def register_production_handlers(context: Context) -> Context:
+    """Register all production RPC handlers for the test dispatcher."""
+
+    def setup(dispatcher: RPCDispatcher) -> None:
+        for name, handler in server.HANDLERS:
+            dispatcher.register(name)(handler)
+
+    context["register"](setup)
+    return context

--- a/features/steps/test_list_references.py
+++ b/features/steps/test_list_references.py
@@ -1,0 +1,177 @@
+import collections.abc as cabc
+import json
+import typing as typ
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+from typer.testing import CliRunner
+
+from features.types import Context
+from weaver.cli import app
+from weaver_schemas.primitives import Location, Position, Range
+from weaver_schemas.references import Reference
+from weaverd import server
+from weaverd.rpc import RPCDispatcher
+from weaverd.serena_tools import SerenaTool
+
+scenarios("../list_references.feature")
+
+
+def _create_runtime_fixture(
+    list_refs_impl: cabc.Callable[..., list[Reference]],
+) -> cabc.Callable[[Context, pytest.MonkeyPatch], Context]:
+    """Return a fixture that configures a stubbed list-references tool."""
+
+    def _fixture(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+        class StubTool:
+            def list_references(
+                self,
+                *,
+                file: str,
+                line: int,
+                char: int,
+                include_definition: bool = False,
+            ) -> list[Reference]:
+                return list_refs_impl(
+                    file, line, char, include_definition=include_definition
+                )
+
+        monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+
+        def setup(dispatcher: RPCDispatcher) -> None:
+            @dispatcher.register("list-references")
+            async def handler(
+                file: str,
+                line: int,
+                char: int,
+                include_definition: bool | None = None,  # noqa: FBT001
+            ) -> cabc.AsyncIterator[Reference]:  # pragma: no cover - stub
+                tool = typ.cast(
+                    typ.Any,  # noqa: TC006
+                    server.create_serena_tool(SerenaTool.LIST_REFERENCES),
+                )
+                for ref in tool.list_references(
+                    file=file,
+                    line=line,
+                    char=char,
+                    include_definition=bool(include_definition),
+                ):
+                    yield ref
+
+        runtime_dir["register"](setup)
+        return runtime_dir
+
+    return _fixture
+
+
+def _return_ref(
+    file: str, line: int, char: int, *, include_definition: bool
+) -> list[Reference]:
+    loc = Location(
+        file="def.py" if include_definition else "ref.py",
+        range=Range(start=Position(line, char), end=Position(line, char + 1)),
+    )
+    return [Reference(location=loc)]
+
+
+def _return_empty(
+    file: str, line: int, char: int, *, include_definition: bool
+) -> list[Reference]:
+    return []
+
+
+@given("a temporary runtime dir", target_fixture="context")
+def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+    return _create_runtime_fixture(_return_ref)(runtime_dir, monkeypatch)
+
+
+@given("a temporary runtime dir with no references", target_fixture="context")
+def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
+    return _create_runtime_fixture(_return_empty)(runtime_dir, monkeypatch)
+
+
+@given("serena-agent is missing")
+def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_error(_: SerenaTool) -> None:
+        raise RuntimeError("serena-agent not found")
+
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+
+
+@when("I invoke the list-references command")
+def invoke(context: Context, tmp_path: Path) -> None:
+    file = tmp_path / "foo.py"
+    file.write_text("pass")
+    runner = CliRunner()
+    try:
+        result = runner.invoke(app, ["list-references", str(file), "1", "0"])
+        context["result"] = result
+    finally:
+        file.unlink(missing_ok=True)
+
+
+@when("I invoke the list-references command with include-definition")
+def invoke_include(context: Context, tmp_path: Path) -> None:
+    file = tmp_path / "foo.py"
+    file.write_text("pass")
+    runner = CliRunner()
+    try:
+        result = runner.invoke(
+            app,
+            ["list-references", "--include-definition", str(file), "1", "0"],
+        )
+        context["result"] = result
+    finally:
+        file.unlink(missing_ok=True)
+
+
+@when("I invoke the list-references command with a missing file")
+def invoke_missing(context: Context) -> None:
+    Path("nope.py").unlink(missing_ok=True)
+    runner = CliRunner()
+    result = runner.invoke(app, ["list-references", "nope.py", "1", "0"])
+    context["result"] = result
+
+
+@then("the output includes a reference line")
+def check_reference(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert lines
+    record = json.loads(lines[0])
+    reference = record.get("reference", record)
+    assert reference.get("type") == "reference"
+
+
+@then("no output is produced")
+def check_empty(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
+
+
+@then("the output includes a definition reference")
+def check_definition_reference(context: Context) -> None:
+    result = context["result"]
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    record = json.loads(lines[0])
+    reference = record.get("reference", record)
+    assert reference.get("location", {}).get("file") == "def.py"
+
+
+@then("the daemon is not ready")
+def check_not_ready(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code == 1
+    out = (result.stdout + result.stderr).lower()
+    assert "serena" in out or "missing" in out
+
+
+@then("the command fails with a missing file error")
+def check_missing_file(context: Context) -> None:
+    result = context["result"]
+    assert result.exit_code != 0
+    out = (result.stdout + result.stderr).lower()
+    assert "no such file" in out or "does not exist" in out

--- a/features/steps/test_list_references.py
+++ b/features/steps/test_list_references.py
@@ -75,31 +75,33 @@ def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
 
-@when("I invoke the list-references command")
-def invoke(context: Context, tmp_path: Path) -> None:
+def _invoke_list_references_command(
+    context: Context, tmp_path: Path, *, include_definition: bool = False
+) -> None:
+    """Invoke the list-references CLI and store the result."""
+
     file = tmp_path / "foo.py"
     file.write_text("pass")
     runner = CliRunner()
     try:
-        result = runner.invoke(app, ["list-references", str(file), "1", "0"])
+        args = ["list-references"]
+        if include_definition:
+            args.append("--include-definition")
+        args.extend([str(file), "1", "0"])
+        result = runner.invoke(app, args)
         context["result"] = result
     finally:
         file.unlink(missing_ok=True)
+
+
+@when("I invoke the list-references command")
+def invoke(context: Context, tmp_path: Path) -> None:
+    _invoke_list_references_command(context, tmp_path)
 
 
 @when("I invoke the list-references command with include-definition")
 def invoke_include(context: Context, tmp_path: Path) -> None:
-    file = tmp_path / "foo.py"
-    file.write_text("pass")
-    runner = CliRunner()
-    try:
-        result = runner.invoke(
-            app,
-            ["list-references", "--include-definition", str(file), "1", "0"],
-        )
-        context["result"] = result
-    finally:
-        file.unlink(missing_ok=True)
+    _invoke_list_references_command(context, tmp_path, include_definition=True)
 
 
 @when("I invoke the list-references command with a missing file")

--- a/features/steps/test_list_references.py
+++ b/features/steps/test_list_references.py
@@ -1,6 +1,5 @@
 import collections.abc as cabc
 import json
-import typing as typ
 from pathlib import Path
 
 import pytest
@@ -18,51 +17,33 @@ from weaverd.serena_tools import SerenaTool
 scenarios("../list_references.feature")
 
 
-def _create_runtime_fixture(
+def _configure_list_refs(
+    runtime_dir: Context,
+    monkeypatch: pytest.MonkeyPatch,
     list_refs_impl: cabc.Callable[..., list[Reference]],
-) -> cabc.Callable[[Context, pytest.MonkeyPatch], Context]:
-    """Return a fixture that configures a stubbed list-references tool."""
+) -> Context:
+    """Register the production handler with a stubbed Serena tool."""
 
-    def _fixture(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
-        class StubTool:
-            def list_references(
-                self,
-                *,
-                file: str,
-                line: int,
-                char: int,
-                include_definition: bool = False,
-            ) -> list[Reference]:
-                return list_refs_impl(
-                    file, line, char, include_definition=include_definition
-                )
+    class StubTool:
+        def list_references(
+            self,
+            *,
+            file: str,
+            line: int,
+            char: int,
+            include_definition: bool = False,
+        ) -> list[Reference]:
+            return list_refs_impl(
+                file, line, char, include_definition=include_definition
+            )
 
-        monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
 
-        def setup(dispatcher: RPCDispatcher) -> None:
-            @dispatcher.register("list-references")
-            async def handler(
-                file: str,
-                line: int,
-                char: int,
-                include_definition: bool | None = None,  # noqa: FBT001
-            ) -> cabc.AsyncIterator[Reference]:  # pragma: no cover - stub
-                tool = typ.cast(
-                    typ.Any,  # noqa: TC006
-                    server.create_serena_tool(SerenaTool.LIST_REFERENCES),
-                )
-                for ref in tool.list_references(
-                    file=file,
-                    line=line,
-                    char=char,
-                    include_definition=bool(include_definition),
-                ):
-                    yield ref
+    def setup(dispatcher: RPCDispatcher) -> None:
+        dispatcher.register("list-references")(server.handle_list_references)
 
-        runtime_dir["register"](setup)
-        return runtime_dir
-
-    return _fixture
+    runtime_dir["register"](setup)
+    return runtime_dir
 
 
 def _return_ref(
@@ -83,12 +64,12 @@ def _return_empty(
 
 @given("a temporary runtime dir", target_fixture="context")
 def runtime_dir(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
-    return _create_runtime_fixture(_return_ref)(runtime_dir, monkeypatch)
+    return _configure_list_refs(runtime_dir, monkeypatch, _return_ref)
 
 
 @given("a temporary runtime dir with no references", target_fixture="context")
 def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> Context:
-    return _create_runtime_fixture(_return_empty)(runtime_dir, monkeypatch)
+    return _configure_list_refs(runtime_dir, monkeypatch, _return_empty)
 
 
 @given("serena-agent is missing")

--- a/features/steps/test_list_references.py
+++ b/features/steps/test_list_references.py
@@ -6,12 +6,12 @@ import pytest
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 
+from features.steps.helpers import register_production_handlers
 from features.types import Context
 from weaver.cli import app
 from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Reference
 from weaverd import server
-from weaverd.rpc import RPCDispatcher
 from weaverd.serena_tools import SerenaTool
 
 scenarios("../list_references.feature")
@@ -22,7 +22,7 @@ def _configure_list_refs(
     monkeypatch: pytest.MonkeyPatch,
     list_refs_impl: cabc.Callable[..., list[Reference]],
 ) -> Context:
-    """Register the production handler with a stubbed Serena tool."""
+    """Register handlers with a stubbed Serena tool."""
 
     class StubTool:
         def list_references(
@@ -38,12 +38,7 @@ def _configure_list_refs(
             )
 
     monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
-
-    def setup(dispatcher: RPCDispatcher) -> None:
-        dispatcher.register("list-references")(server.handle_list_references)
-
-    runtime_dir["register"](setup)
-    return runtime_dir
+    return register_production_handlers(runtime_dir)
 
 
 def _return_ref(

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -113,9 +113,32 @@ def get_definition(
     _run_rpc("get-definition", params)
 
 
+@app.command("list-references")
+def list_references(
+    file: Path = typer.Argument(  # noqa: B008
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=False,
+    ),
+    line: int = typer.Argument(..., min=0),
+    char: int = typer.Argument(..., min=0),
+    include_definition: bool = typer.Option(  # noqa: FBT001
+        default=False, help="Include symbol definition in results"
+    ),
+) -> None:
+    """Locate all references to the symbol at the given position."""
+
+    params: dict[str, typ.Any] = {"file": str(file), "line": line, "char": char}
+    if include_definition:
+        params["include_definition"] = True
+    _run_rpc("list-references", params)
+
+
 STUBS = [
     "find-symbol",
-    "list-references",
     "summarise-symbol",
     "get-call-graph",
     "get-type-hierarchy",

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -77,6 +77,12 @@ class CLITestCase:
             [__file__, "1", "2"],
             {"file": __file__, "line": 1, "char": 2},
         ),
+        CLITestCase(
+            "list-references",
+            "list-references",
+            [__file__, "1", "2"],
+            {"file": __file__, "line": 1, "char": 2},
+        ),
     ],
 )
 def test_cli_commands_use_run_rpc(
@@ -99,6 +105,37 @@ def test_cli_commands_use_run_rpc(
         "func": cli.rpc_call,
         "method": test_case.rpc_method,
         "params": test_case.params,
+    }
+
+
+def test_cli_list_references_include_definition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list-references forwards include-definition flag to RPC."""
+
+    called: dict[str, object] = {}
+
+    def fake_run(func, method, params=None):
+        called.update({"func": func, "method": method, "params": params})
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["list-references", "--include-definition", __file__, "1", "2"],
+    )
+
+    assert result.exit_code == 0
+    assert called == {
+        "func": cli.rpc_call,
+        "method": "list-references",
+        "params": {
+            "file": __file__,
+            "line": 1,
+            "char": 2,
+            "include_definition": True,
+        },
     }
 
 

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -32,6 +32,7 @@ class SerenaTool(enum.StrEnum):
     ONBOARDING = "OnboardingTool"
     LIST_DIAGNOSTICS = "ListDiagnosticsTool"
     GET_DEFINITION = "GetDefinitionTool"
+    LIST_REFERENCES = "ListReferencesTool"
 
 
 _VALID_TOOL_MEMBER_NAMES = frozenset(SerenaTool.__members__.keys())

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -17,7 +17,7 @@ import msgspec.json as msjson
 
 from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.error import SchemaError
-from weaver_schemas.references import Symbol
+from weaver_schemas.references import Reference, Symbol
 from weaver_schemas.reports import OnboardingReport
 from weaver_schemas.status import ProjectStatus
 
@@ -224,6 +224,34 @@ async def handle_get_definition(
         raise RuntimeError(f"Definition lookup failed: {exc}") from exc
     for item in data:
         yield ms.convert(item, Symbol)
+
+
+@rpc_handler("list-references")
+async def handle_list_references(
+    file: str,
+    line: int,
+    char: int,
+    *,
+    include_definition: bool | None = None,
+) -> typ.AsyncIterator[Reference]:
+    """Yield references for the symbol at the given position."""
+
+    tool = typ.cast(
+        typ.Any,  # noqa: TC006
+        create_serena_tool(SerenaTool.LIST_REFERENCES),
+    )
+    try:
+        data = await asyncio.to_thread(
+            tool.list_references,
+            file=file,
+            line=line,
+            char=char,
+            include_definition=bool(include_definition),
+        )
+    except RuntimeError as exc:
+        raise RuntimeError(f"Reference lookup failed: {exc}") from exc
+    for item in data:
+        yield ms.convert(item, Reference)
 
 
 async def main(socket_path: Path | None = None) -> None:

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -232,7 +232,7 @@ async def handle_list_references(
     line: int,
     char: int,
     *,
-    include_definition: bool | None = None,
+    include_definition: bool = False,
 ) -> typ.AsyncIterator[Reference]:
     """Yield references for the symbol at the given position."""
 
@@ -246,7 +246,7 @@ async def handle_list_references(
             file=file,
             line=line,
             char=char,
-            include_definition=bool(include_definition),
+            include_definition=include_definition,
         )
     except RuntimeError as exc:
         raise RuntimeError(f"Reference lookup failed: {exc}") from exc

--- a/weaverd/unittests/test_references.py
+++ b/weaverd/unittests/test_references.py
@@ -1,0 +1,64 @@
+import builtins
+
+import pytest
+
+from weaver_schemas.primitives import Location, Position, Range
+from weaver_schemas.references import Reference
+from weaverd import server
+from weaverd.serena_tools import SerenaTool
+
+
+class StubTool:
+    def list_references(
+        self, *, file: str, line: int, char: int, include_definition: bool = False
+    ) -> list[Reference]:
+        loc = Location(
+            file=file,
+            range=Range(start=Position(line, char), end=Position(line, char + 1)),
+        )
+        return [Reference(location=loc)]
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_handle_list_references(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: StubTool())
+    results = server.handle_list_references("foo.py", 1, 0)
+    ref = await builtins.anext(results)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert ref.location.file == "foo.py"
+
+
+class EmptyTool:
+    def list_references(
+        self, *, file: str, line: int, char: int, include_definition: bool = False
+    ) -> list[Reference]:
+        return []
+
+
+@pytest.mark.anyio
+async def test_handle_list_references_no_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: EmptyTool())
+    results = server.handle_list_references("foo.py", 1, 0)
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+
+
+@pytest.mark.anyio
+async def test_handle_list_references_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_error(_: SerenaTool) -> None:
+        raise RuntimeError("serena-agent not found")
+
+    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+
+    with pytest.raises(RuntimeError, match="serena-agent not found"):
+        await builtins.anext(server.handle_list_references("foo.py", 1, 0))

--- a/weaverd/unittests/test_references.py
+++ b/weaverd/unittests/test_references.py
@@ -62,3 +62,19 @@ async def test_handle_list_references_missing_dependency(
 
     with pytest.raises(RuntimeError, match="serena-agent not found"):
         await builtins.anext(server.handle_list_references("foo.py", 1, 0))
+
+
+class FailingTool:
+    def list_references(
+        self, *, file: str, line: int, char: int, include_definition: bool = False
+    ) -> list[Reference]:
+        raise RuntimeError("boom")
+
+
+@pytest.mark.anyio
+async def test_handle_list_references_wraps_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "create_serena_tool", lambda _: FailingTool())
+    with pytest.raises(RuntimeError, match="Reference lookup failed: boom"):
+        await builtins.anext(server.handle_list_references("foo.py", 1, 0))

--- a/weaverd/unittests/test_serena_tools.py
+++ b/weaverd/unittests/test_serena_tools.py
@@ -14,6 +14,8 @@ from weaverd.serena_tools import (
     [
         ("onboarding", "OnboardingTool"),
         ("OnboardingTool", "OnboardingTool"),
+        ("list_references", "ListReferencesTool"),
+        ("ListReferencesTool", "ListReferencesTool"),
     ],
 )
 def test_resolve_string_tool_name_success(input_name: str, expected: str) -> None:


### PR DESCRIPTION
## Summary
- support listing symbol references via Serena's ListReferencesTool
- expose new `list-references` orient command in the CLI
- document design and mark roadmap entry complete

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_689ef9fd5f748322ab67b5f6b97a51fb

## Summary by Sourcery

Add a new list-references feature by implementing a CLI command and RPC handler that wraps Serena’s ListReferencesTool, support the include-definition option, update documentation, and cover with unit and BDD tests.

New Features:
- Introduce list-references CLI command with optional --include-definition flag
- Implement list-references RPC handler to stream symbol references via SerenaTool

Enhancements:
- Add LIST_REFERENCES member to SerenaTool enum
- Document the list-references handler in design doc and mark roadmap entry complete

Documentation:
- Update weaver-design.md and roadmap.md to describe the new list-references command

Tests:
- Add unit tests for CLI invocation, RPC handler, and tool resolution
- Add BDD feature tests covering various list-references scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a list-references CLI command to find all references to a symbol at a given file, line, and character.
  - Supports an --include-definition flag to optionally include the symbol’s defining location.
  - Clear error reporting for missing files or unavailable dependencies.

- **Documentation**
  - Added usage docs for list-references and updated the roadmap status.

- **Tests**
  - Added unit and end-to-end tests covering include-definition, no-results, missing-file, missing-dependency, and streaming results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->