### PR TITLE
Guard type-only imports in step helpers

### DIFF
--- a/features/steps/helpers.py
+++ b/features/steps/helpers.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import typing as typ
+from typing import TYPE_CHECKING  # noqa: ICN003
 
-if typ.TYPE_CHECKING:
+if TYPE_CHECKING:
     from features.types import Context
     from weaverd.rpc import RPCDispatcher
 
-__all__ = ("register_production_handlers",)
+__all__: tuple[str, ...] = ("register_production_handlers",)
 
 
 def register_production_handlers(context: Context) -> Context:

--- a/features/steps/helpers.py
+++ b/features/steps/helpers.py
@@ -1,14 +1,35 @@
 """Shared helpers for BDD step implementations."""
 
-from features.types import Context
-from weaverd import server
-from weaverd.rpc import RPCDispatcher
+from __future__ import annotations
+
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from features.types import Context
+    from weaverd.rpc import RPCDispatcher
+
+__all__ = ("register_production_handlers",)
 
 
 def register_production_handlers(context: Context) -> Context:
-    """Register all production RPC handlers for the test dispatcher."""
+    """Register production RPC handlers on the test dispatcher.
+
+    Parameters
+    ----------
+    context : Context
+        Test context that provides a "register" hook accepting a callable
+        of shape (dispatcher: RPCDispatcher) -> None.
+
+    Returns
+    -------
+    Context
+        The same context, to enable fluent usage in step setup.
+    """
 
     def setup(dispatcher: RPCDispatcher) -> None:
+        # Import lazily to avoid import-time side effects in tests.
+        from weaverd import server
+
         for name, handler in server.HANDLERS:
             dispatcher.register(name)(handler)
 


### PR DESCRIPTION
## Summary
- future-proof BDD step helpers with postponed annotations and explicit exports
- document `register_production_handlers` using NumPy-style sections
- import `server` lazily to avoid side effects during tests

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a126667a1c8322880724da6286c29d

## Summary by Sourcery

Future-proof BDD step helpers by enabling postponed annotations, guarding type-only imports, explicitly exporting functions, lazily importing the server to avoid test side effects, and improving docstrings

Enhancements:
- Guard type-only imports with typing.TYPE_CHECKING and enable postponed annotations
- Move server import into function to prevent import-time side effects in tests
- Add __all__ for explicit export of register_production_handlers

Documentation:
- Revamp register_production_handlers docstring with NumPy-style parameter and return sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Reduced import-time overhead by deferring heavy dependency loading until needed, lowering startup side effects and improving runtime predictability.
  - Preserved public API and fluent wiring behavior while simplifying handler registration at runtime.
- Documentation
  - Expanded inline documentation to clarify context usage, setup callback behavior, and return semantics for easier integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->