### PR TITLE
Enable logging, log formatting, quotes, and Pytest style lint rules

### DIFF
--- a/features/conftest.py
+++ b/features/conftest.py
@@ -101,7 +101,7 @@ def _cleanup_processes(processes: list[mp.Process]) -> None:
         _cleanup_process(proc)
 
 
-@pytest.fixture()
+@pytest.fixture
 def runtime_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> cabc.Generator[Context, None, None]:

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -102,7 +102,8 @@ def check(context: Context) -> None:
     assert result.exit_code == 0
     assert result.stdout.strip()
     out = result.stdout.lower()
-    assert "project" in out and ("viewing" in out or "onboarding" in out)
+    assert "project" in out
+    assert "viewing" in out or "onboarding" in out
 
 
 @then("the command fails with an error message")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ select = [
     "N",        # enforce naming conventions, e.g. ClassName vs function_name
     "FURB",      # Refurb-style suggestions
     "B",         # Bugbear warnings
+    "LOG",      # Logging
+    "G",        # Log formatting
+    "Q",        # Quotes
+    "PT",       # PyTest style issues
     "RUF",
 ]
 per-file-ignores = {"**/test_*.py" = ["S101"]}

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -15,7 +15,7 @@ from weaverd.rpc import RPCDispatcher
 from weaverd.server import start_server
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 

--- a/weaver/unittests/test_sockets.py
+++ b/weaver/unittests/test_sockets.py
@@ -6,7 +6,7 @@ import pytest
 from weaver.sockets import can_connect
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -99,7 +99,7 @@ def _assert_symbol_location(symbol: Symbol, expected_location: Location) -> None
     assert symbol.location.range.end.character == expected_location.range.end.character
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
@@ -180,10 +180,13 @@ async def test_handle_get_definition_missing_dependency(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("line,char", [(-1, 0), (1, -5), (-2, -3)])
+@pytest.mark.parametrize(("line", "char"), [(-1, 0), (1, -5), (-2, -3)])
 async def test_handle_get_definition_invalid_position(
     monkeypatch: pytest.MonkeyPatch, line: int, char: int
 ) -> None:
     monkeypatch.setattr(server, "create_serena_tool", lambda _: DummyTool())
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="non-negative",
+    ):
         await anext(server.handle_get_definition("foo.py", line, char))

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -27,12 +27,12 @@ class StubTool:
         return [Diagnostic(location=loc, severity="Error", code="E1", message="boom")]
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def diagnostics_test_server(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> typ.AsyncIterator[Path]:

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -15,7 +15,7 @@ from weaverd.serena_tools import SerenaTool, create_serena_tool
 from weaverd.server import start_server
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
@@ -42,7 +42,8 @@ async def test_onboard_project(tmp_path: Path) -> None:
             data = await asyncio.wait_for(reader.readline(), timeout=5.0)
             report = msjson.decode(data.rstrip(), type=OnboardingReport)
             text = report.details.lower()
-            assert "viewing" in text and "project" in text
+            assert "viewing" in text
+            assert "project" in text
             assert len(report.details) > 20
         finally:
             if writer is not None:

--- a/weaverd/unittests/test_references.py
+++ b/weaverd/unittests/test_references.py
@@ -19,7 +19,7 @@ class StubTool:
         return [Reference(location=loc)]
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -11,7 +11,7 @@ from weaver_schemas.status import ProjectStatus
 from weaverd.rpc import RPCDispatcher
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
@@ -78,7 +78,8 @@ async def test_dispatcher_returns_error_on_bad_json() -> None:
 
     results = dispatcher.handle(b"not-json")
     err = msjson.decode(await builtins.anext(results), type=SchemaError)
-    assert err.type == "error" and "invalid request" in err.message
+    assert err.type == "error"
+    assert "invalid request" in err.message
 
 
 @pytest.mark.anyio
@@ -115,4 +116,5 @@ async def test_dispatcher_streams_midstream_error() -> None:
     err = msjson.decode(await builtins.anext(results), type=SchemaError)
     with pytest.raises(StopAsyncIteration):
         await builtins.anext(results)
-    assert first == 1 and err.message == "boom"
+    assert first == 1
+    assert err.message == "boom"

--- a/weaverd/unittests/test_server.py
+++ b/weaverd/unittests/test_server.py
@@ -11,7 +11,7 @@ from weaverd.rpc import RPCDispatcher
 from weaverd.server import start_server
 
 
-@pytest.fixture()
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
@@ -84,7 +84,7 @@ def test_rpc_handler_rejects_duplicates() -> None:
         def first() -> None:
             pass
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="already registered"):
 
             @srv.rpc_handler("dup")
             def second() -> None:  # pragma: no cover - stub


### PR DESCRIPTION
## Summary
- enforce consistent string quotes via Ruff by enabling the Q rule
- ensure logging best practices and formatting by enabling the LOG and G rules
- enforce Pytest style via the PT rule, updating fixtures and tests accordingly

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5271866908322b720c063d95b89ed

## Summary by Sourcery

Enforce logging, quote, and Pytest style lint rules via Ruff and adjust existing tests to satisfy the new rules

Enhancements:
- Enable logging best-practices (LOG, G) and string-quote (Q) rules in Ruff configuration
- Enable Pytest style (PT) rules in Ruff configuration

Tests:
- Remove empty parentheses from @pytest.fixture decorators
- Convert pytest.mark.parametrize calls to use tuple argument signatures
- Add match patterns to pytest.raises calls and split compound assertions into separate lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Split compound assertions into separate checks for clearer failures across onboarding, RPC, and related tests.
  * Added explicit error message matching in selected raises assertions.
  * Updated parametrize declarations to tuple form in one test.

* **Style**
  * Standardized PyTest fixture decorators by removing empty-call parentheses across multiple test files.

* **Chores**
  * Expanded linting rules by enabling additional Ruff codes (logging, log formatting, quotes, PyTest style).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->