### PR TITLE
Prune unused data science import aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,12 +85,6 @@ banned-from = [
 
 [tool.ruff.lint.flake8-import-conventions.aliases]
 # Declare the default aliases.
-altair = "alt"
-"matplotlib.pyplot" = "plt"
-numpy = "np"
-pandas = "pd"
-seaborn = "sns"
-scipy = "sp"
 "collections.abc" = "cabc"
 datetime = "dt"
 "unittest.mock" = "mock"


### PR DESCRIPTION
## Summary
- remove unused import-alias conventions for data-science libraries to avoid lint noise

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a591faf34c832280a7573d7004cabc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to adjust import alias conventions, removing several default alias mappings to better align with current style guidelines.
  * Streamlines developer tooling and reduces maintenance overhead without affecting application behavior.
  * No changes to features, performance, or public APIs; end users will see no differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->