### PR TITLE
Enforce TRY linting with custom exceptions

### DIFF
--- a/features/conftest.py
+++ b/features/conftest.py
@@ -23,13 +23,21 @@ async def _wait_for_socket(path: Path, timeout: float = 5.0) -> None:
     while anyio.current_time() < deadline:
         try:
             _, writer = await asyncio.open_unix_connection(str(path))
+        except OSError:
+            await anyio.sleep(0.05)
+        else:
             writer.close()
             with contextlib.suppress(Exception):
                 await writer.wait_closed()
             return
-        except OSError:
-            await anyio.sleep(0.05)
-    raise TimeoutError(f"Daemon socket not ready: {path}")
+    raise DaemonNotReadyError(path)
+
+
+class DaemonNotReadyError(TimeoutError):
+    """Raised when the test daemon fails to accept connections."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"Daemon socket not ready: {path}")
 
 
 async def _serve_daemon(path: Path, handler_func: HandlerFunc) -> None:

--- a/features/conftest.py
+++ b/features/conftest.py
@@ -30,14 +30,15 @@ async def _wait_for_socket(path: Path, timeout: float = 5.0) -> None:
             with contextlib.suppress(Exception):
                 await writer.wait_closed()
             return
-    raise DaemonNotReadyError(path)
+    raise DaemonNotReadyError(path, timeout)
 
 
 class DaemonNotReadyError(TimeoutError):
     """Raised when the test daemon fails to accept connections."""
 
-    def __init__(self, path: Path) -> None:
-        super().__init__(f"Daemon socket not ready: {path}")
+    def __init__(self, path: Path, timeout: float | None = None) -> None:
+        suffix = f" (after {timeout:.2f}s)" if timeout is not None else ""
+        super().__init__(f"Daemon socket not ready: {path}{suffix}")
 
 
 async def _serve_daemon(path: Path, handler_func: HandlerFunc) -> None:

--- a/features/steps/helpers.py
+++ b/features/steps/helpers.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import typing as typ
 from typing import TYPE_CHECKING  # noqa: ICN003
+
+from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
 
 if TYPE_CHECKING:
     from features.types import Context
     from weaverd.rpc import RPCDispatcher
 
-__all__: tuple[str, ...] = ("register_production_handlers",)
+__all__: tuple[str, ...] = (
+    "raise_serena_agent_not_found",
+    "register_production_handlers",
+)
 
 
 def register_production_handlers(context: Context) -> Context:
@@ -35,3 +41,13 @@ def register_production_handlers(context: Context) -> Context:
 
     context["register"](setup)
     return context
+
+
+def raise_serena_agent_not_found(_: SerenaTool) -> typ.NoReturn:
+    """Raise :class:`SerenaAgentNotFoundError` for missing serena-agent.
+
+    Centralizing this stub avoids repetition across step definitions and makes
+    updates to the error behaviour straightforward.
+    """
+
+    raise SerenaAgentNotFoundError()

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -13,7 +13,7 @@ from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Symbol
 from weaverd import server
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import SerenaTool
+from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
 
 scenarios("../get_definition.feature")
 
@@ -73,7 +73,7 @@ def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     def raise_error(_: SerenaTool) -> None:
-        raise RuntimeError("serena-agent not found")
+        raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 

--- a/features/steps/test_get_definition.py
+++ b/features/steps/test_get_definition.py
@@ -13,7 +13,9 @@ from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Symbol
 from weaverd import server
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
+from weaverd.serena_tools import SerenaTool
+
+from .helpers import raise_serena_agent_not_found
 
 scenarios("../get_definition.feature")
 
@@ -72,10 +74,7 @@ def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> 
 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error(_: SerenaTool) -> None:
-        raise SerenaAgentNotFoundError()
-
-    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+    monkeypatch.setattr(server, "create_serena_tool", raise_serena_agent_not_found)
 
 
 @when("I invoke the get-definition command")

--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -13,7 +13,11 @@ from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.primitives import Location, Position, Range
 from weaverd import serena_tools, server
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import SerenaTool
+from weaverd.serena_tools import (
+    SerenaAgentNotFoundError,
+    SerenaTool,
+    ToolClassNotFoundError,
+)
 
 scenarios("../list_diagnostics.feature")
 
@@ -65,7 +69,7 @@ def daemon_running(context: Context) -> None:
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     def raise_error(_: SerenaTool) -> None:
-        raise RuntimeError("serena-agent not found")
+        raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
@@ -73,7 +77,7 @@ def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
 @given("the tool attribute is unknown")
 def unknown_tool(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
     def raise_error(_: SerenaTool) -> None:
-        raise RuntimeError("NoSuchTool not found in serena")
+        raise ToolClassNotFoundError("NoSuchTool")
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 

--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -13,11 +13,9 @@ from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.primitives import Location, Position, Range
 from weaverd import serena_tools, server
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import (
-    SerenaAgentNotFoundError,
-    SerenaTool,
-    ToolClassNotFoundError,
-)
+from weaverd.serena_tools import SerenaTool, ToolClassNotFoundError
+
+from .helpers import raise_serena_agent_not_found
 
 scenarios("../list_diagnostics.feature")
 
@@ -68,15 +66,12 @@ def daemon_running(context: Context) -> None:
 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error(_: SerenaTool) -> None:
-        raise SerenaAgentNotFoundError()
-
-    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+    monkeypatch.setattr(server, "create_serena_tool", raise_serena_agent_not_found)
 
 
 @given("the tool attribute is unknown")
 def unknown_tool(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error(_: SerenaTool) -> None:
+    def raise_error(_: SerenaTool) -> typ.NoReturn:
         raise ToolClassNotFoundError("NoSuchTool")
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)

--- a/features/steps/test_list_references.py
+++ b/features/steps/test_list_references.py
@@ -6,13 +6,15 @@ import pytest
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 
-from features.steps.helpers import register_production_handlers
+from features.steps.helpers import (
+    raise_serena_agent_not_found,
+    register_production_handlers,
+)
 from features.types import Context
 from weaver.cli import app
 from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Reference
 from weaverd import server
-from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
 
 scenarios("../list_references.feature")
 
@@ -69,10 +71,7 @@ def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> 
 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
-    def raise_error(_: SerenaTool) -> None:
-        raise SerenaAgentNotFoundError()
-
-    monkeypatch.setattr(server, "create_serena_tool", raise_error)
+    monkeypatch.setattr(server, "create_serena_tool", raise_serena_agent_not_found)
 
 
 def _invoke_list_references_command(

--- a/features/steps/test_list_references.py
+++ b/features/steps/test_list_references.py
@@ -12,7 +12,7 @@ from weaver.cli import app
 from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Reference
 from weaverd import server
-from weaverd.serena_tools import SerenaTool
+from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
 
 scenarios("../list_references.feature")
 
@@ -70,7 +70,7 @@ def runtime_dir_empty(runtime_dir: Context, monkeypatch: pytest.MonkeyPatch) -> 
 @given("serena-agent is missing")
 def missing_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     def raise_error(_: SerenaTool) -> None:
-        raise RuntimeError("serena-agent not found")
+        raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -68,7 +68,10 @@ def tool_error(context: Context, monkeypatch) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
         class FailingTool:
             def apply(self) -> str:  # pragma: no cover - stub
-                raise RuntimeError("boom")
+                class ToolApplyError(RuntimeError):
+                    """Test-only error to simulate tool failure."""
+
+                raise ToolApplyError("boom")
 
         @dispatcher.register("onboard-project")
         def onboard() -> OnboardingReport:  # pragma: no cover - stub

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -12,7 +12,11 @@ from features.types import Context
 from weaver.cli import app
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import SerenaTool, create_serena_tool
+from weaverd.serena_tools import (
+    SerenaAgentNotFoundError,
+    SerenaTool,
+    create_serena_tool,
+)
 
 scenarios("../onboard_project.feature")
 
@@ -23,7 +27,7 @@ def runtime_dir(runtime_dir: Context) -> Context:
         @dispatcher.register("onboard-project")
         def onboard() -> OnboardingReport:  # pragma: no cover - stub
             if os.environ.get("WEAVER_TEST_MISSING_SERENA"):
-                raise RuntimeError("serena-agent not found")
+                raise SerenaAgentNotFoundError()
             tool = typ.cast(typ.Any, create_serena_tool(SerenaTool.ONBOARDING))  # noqa: TC006
             return OnboardingReport(details=tool.apply())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "weaver package"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }
-authors = [{ name = "Weaver Contributors", email = "opensource@weaver.dev" }]
+authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
 keywords = ["weaver", "rpc"]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ description = "weaver package"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }
-authors = [{ name = "Weaver Contributors" }]
+authors = [{ name = "Weaver Contributors", email = "opensource@weaver.dev" }]
 keywords = ["weaver", "rpc"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "anyio!=4.9.0,>=4.9.1,<5.0",
@@ -20,6 +21,15 @@ dependencies = [
 [project.scripts]
 weaver = "weaver.cli:app"
 weaverd = "weaverd.server:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "ruff==0.12.7",
+    "pyright",
+    "pytest-timeout",
+    "pytest-bdd>=8.1.0",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ select = [
     "N",        # enforce naming conventions, e.g. ClassName vs function_name
     "FURB",      # Refurb-style suggestions
     "B",         # Bugbear warnings
+    "TRY",      # Exception handling best practices
     "LOG",      # Logging
     "G",        # Log formatting
     "Q",        # Quotes

--- a/uv.lock
+++ b/uv.lock
@@ -1010,6 +1010,15 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-bdd" },
+    { name = "pytest-timeout" },
+    { name = "ruff" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pyright" },
@@ -1023,9 +1032,15 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = "!=4.9.0,>=4.9.1,<5.0" },
     { name = "msgspec", specifier = ">=0.19.0,<1.0" },
+    { name = "pyright", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-bdd", marker = "extra == 'dev'", specifier = ">=8.1.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.7" },
     { name = "serena-agent", specifier = "==0.1.3" },
     { name = "typer", specifier = ">=0.16.0,<1.0" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -26,6 +26,13 @@ JSONValue: typ.TypeAlias = (
 JSONObject: typ.TypeAlias = dict[str, JSONValue]
 
 
+class DaemonStartError(RuntimeError):
+    """Raised when ``weaverd`` fails to become ready."""
+
+    def __init__(self) -> None:
+        super().__init__("weaverd failed to start")
+
+
 def discover_socket() -> Path:
     """Return the daemon socket path."""
     return default_socket_path()
@@ -59,7 +66,7 @@ async def ensure_daemon_running(socket_path: Path) -> None:
         if await can_connect(socket_path):
             return
         await anyio.sleep(0.1)
-    raise RuntimeError("weaverd failed to start")
+    raise DaemonStartError()
 
 
 def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -99,26 +99,35 @@ async def _stream_response(reader: asyncio.StreamReader, stdout: typ.TextIO) -> 
     return error
 
 
-async def rpc_call(
-    method: str,
-    params: JSONObject | None = None,
-    socket_path: Path | None = None,
-    stdout: typ.TextIO | None = None,
-) -> None:
-    """Send an RPC request and stream the response to ``stdout``."""
-    path = socket_path or discover_socket()
-    stdout = typ.cast(typ.TextIO, sys.stdout if stdout is None else stdout)  # noqa: TC006
+def _resolve_socket_path(socket_path: Path | None) -> Path:
+    """Return ``socket_path`` or discover a fallback."""
+    return socket_path or discover_socket()
+
+
+async def _establish_rpc_connection(
+    path: Path,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Ensure the daemon is running and open a Unix socket connection."""
     try:
         await ensure_daemon_running(path)
     except DaemonStartError as exc:
         print(f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr)
         raise typer.Exit(1) from exc
-
     try:
-        reader, writer = await asyncio.open_unix_connection(str(path))
+        return await asyncio.open_unix_connection(str(path))
     except OSError as exc:
         print(f"Error: Failed to connect to daemon at {path}: {exc}", file=sys.stderr)
         raise typer.Exit(1) from exc
+
+
+async def _execute_rpc_request(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    method: str,
+    params: JSONObject | None,
+    stdout: typ.TextIO,
+) -> bool:
+    """Send an RPC request and stream the response."""
     error = False
     try:
         writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
@@ -128,6 +137,20 @@ async def rpc_call(
     finally:
         writer.close()
         await writer.wait_closed()
+    return error
+
+
+async def rpc_call(
+    method: str,
+    params: JSONObject | None = None,
+    socket_path: Path | None = None,
+    stdout: typ.TextIO | None = None,
+) -> None:
+    """Send an RPC request and stream the response to ``stdout``."""
+    path = _resolve_socket_path(socket_path)
+    stdout = typ.cast(typ.TextIO, sys.stdout if stdout is None else stdout)  # noqa: TC006
+    reader, writer = await _establish_rpc_connection(path)
+    error = await _execute_rpc_request(reader, writer, method, params, stdout)
     if error:
         raise typer.Exit(1)
     return

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -31,6 +31,13 @@ JSONValue: typ.TypeAlias = (
 JSONObject: typ.TypeAlias = dict[str, JSONValue]
 
 
+class RPCRequest(ms.Struct):
+    """An RPC request with method and parameters."""
+
+    method: str
+    params: JSONObject | None = None
+
+
 class DaemonStartError(TimeoutError):
     """Raised when ``weaverd`` fails to become ready."""
 
@@ -132,14 +139,16 @@ async def _establish_rpc_connection(
 async def _execute_rpc_request(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
-    method: str,
-    params: JSONObject | None,
+    request: RPCRequest,
     stdout: typ.TextIO,
 ) -> bool:
     """Send an RPC request and stream the response."""
     error = False
     try:
-        writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
+        writer.write(
+            msjson.encode({"method": request.method, "params": request.params or {}})
+            + b"\n"
+        )
         await writer.drain()
         with contextlib.suppress(
             AttributeError, NotImplementedError
@@ -162,7 +171,8 @@ async def rpc_call(
     path = _resolve_socket_path(socket_path)
     stdout = typ.cast(typ.TextIO, sys.stdout if stdout is None else stdout)  # noqa: TC006
     reader, writer = await _establish_rpc_connection(path)
-    error = await _execute_rpc_request(reader, writer, method, params, stdout)
+    request = RPCRequest(method=method, params=params)
+    error = await _execute_rpc_request(reader, writer, request, stdout)
     if error:
         raise typer.Exit(1)
     return

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -26,7 +26,7 @@ JSONValue: typ.TypeAlias = (
 JSONObject: typ.TypeAlias = dict[str, JSONValue]
 
 
-class DaemonStartError(RuntimeError):
+class DaemonStartError(TimeoutError):
     """Raised when ``weaverd`` fails to become ready."""
 
     def __init__(self) -> None:

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 # Daemon startup policy
 STARTUP_RETRIES = 50
 STARTUP_SLEEP_SECS = 0.1
+STARTUP_TIMEOUT_SECS: float = STARTUP_RETRIES * STARTUP_SLEEP_SECS
 
 JSONValue: typ.TypeAlias = (
     bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"] | None
@@ -41,8 +42,12 @@ class RPCRequest(ms.Struct):
 class DaemonStartError(TimeoutError):
     """Raised when ``weaverd`` fails to become ready."""
 
-    def __init__(self) -> None:
-        super().__init__("weaverd failed to start")
+    def __init__(self, path: Path, timeout_secs: float) -> None:
+        self.path = path
+        self.timeout_secs = timeout_secs
+        super().__init__(
+            f"weaverd failed to start at {path} within {timeout_secs:.1f}s"
+        )
 
 
 def discover_socket() -> Path:
@@ -74,11 +79,15 @@ async def ensure_daemon_running(socket_path: Path) -> None:
     if await can_connect(socket_path):
         return
     await spawn_daemon(socket_path)
-    for _ in range(STARTUP_RETRIES):
-        if await can_connect(socket_path):
-            return
-        await anyio.sleep(STARTUP_SLEEP_SECS)
-    raise DaemonStartError()
+    try:
+        with anyio.fail_after(STARTUP_TIMEOUT_SECS):
+            for _ in range(STARTUP_RETRIES):
+                if await can_connect(socket_path):
+                    return
+                await anyio.sleep(STARTUP_SLEEP_SECS)
+    except TimeoutError as exc:
+        raise DaemonStartError(socket_path, STARTUP_TIMEOUT_SECS) from exc
+    raise DaemonStartError(socket_path, STARTUP_TIMEOUT_SECS)
 
 
 def _process_response_line(data: bytes, stdout: typ.TextIO) -> bool:
@@ -122,18 +131,11 @@ async def _establish_rpc_connection(
     """Ensure the daemon is running and open a Unix socket connection.
 
     Raises:
-        typer.Exit: If the daemon fails to start or the Unix socket cannot be opened.
+        DaemonStartError: If the daemon fails to start.
+        OSError: If the Unix socket cannot be opened.
     """
-    try:
-        await ensure_daemon_running(path)
-    except DaemonStartError as exc:
-        print(f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr)
-        raise typer.Exit(1) from exc
-    try:
-        return await asyncio.open_unix_connection(str(path))
-    except OSError as exc:
-        print(f"Error: Failed to connect to daemon at {path}: {exc}", file=sys.stderr)
-        raise typer.Exit(1) from exc
+    await ensure_daemon_running(path)
+    return await asyncio.open_unix_connection(str(path))
 
 
 async def _execute_rpc_request(
@@ -143,7 +145,6 @@ async def _execute_rpc_request(
     stdout: typ.TextIO,
 ) -> bool:
     """Send an RPC request and stream the response."""
-    error = False
     try:
         writer.write(
             msjson.encode({"method": request.method, "params": request.params or {}})
@@ -154,11 +155,10 @@ async def _execute_rpc_request(
             AttributeError, NotImplementedError
         ):  # pragma: no cover - transport-specific
             writer.write_eof()
-        error = await _stream_response(reader, stdout)
+        return await _stream_response(reader, stdout)
     finally:
         writer.close()
         await writer.wait_closed()
-    return error
 
 
 async def rpc_call(
@@ -170,7 +170,14 @@ async def rpc_call(
     """Send an RPC request and stream the response to ``stdout``."""
     path = _resolve_socket_path(socket_path)
     stdout = typ.cast(typ.TextIO, sys.stdout if stdout is None else stdout)  # noqa: TC006
-    reader, writer = await _establish_rpc_connection(path)
+    try:
+        reader, writer = await _establish_rpc_connection(path)
+    except DaemonStartError as exc:
+        print(f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr)
+        raise typer.Exit(1) from exc
+    except OSError as exc:
+        print(f"Error: Failed to connect to daemon at {path}: {exc}", file=sys.stderr)
+        raise typer.Exit(1) from exc
     request = RPCRequest(method=method, params=params)
     error = await _execute_rpc_request(reader, writer, request, stdout)
     if error:

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -110,11 +110,15 @@ async def rpc_call(
     stdout = typ.cast(typ.TextIO, sys.stdout if stdout is None else stdout)  # noqa: TC006
     try:
         await ensure_daemon_running(path)
-    except Exception as exc:
+    except DaemonStartError as exc:
         print(f"Error: Could not ensure daemon is running: {exc}", file=sys.stderr)
         raise typer.Exit(1) from exc
 
-    reader, writer = await asyncio.open_unix_connection(str(path))
+    try:
+        reader, writer = await asyncio.open_unix_connection(str(path))
+    except OSError as exc:
+        print(f"Error: Failed to connect to daemon at {path}: {exc}", file=sys.stderr)
+        raise typer.Exit(1) from exc
     error = False
     try:
         writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")

--- a/weaver/client.py
+++ b/weaver/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.subprocess as aio_subprocess
+import contextlib
 import logging
 import os
 import sys
@@ -19,6 +20,10 @@ from .errors import is_dependency_error
 from .sockets import can_connect
 
 logger = logging.getLogger(__name__)
+
+# Daemon startup policy
+STARTUP_RETRIES = 50
+STARTUP_SLEEP_SECS = 0.1
 
 JSONValue: typ.TypeAlias = (
     bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"] | None
@@ -62,10 +67,10 @@ async def ensure_daemon_running(socket_path: Path) -> None:
     if await can_connect(socket_path):
         return
     await spawn_daemon(socket_path)
-    for _ in range(50):
+    for _ in range(STARTUP_RETRIES):
         if await can_connect(socket_path):
             return
-        await anyio.sleep(0.1)
+        await anyio.sleep(STARTUP_SLEEP_SECS)
     raise DaemonStartError()
 
 
@@ -107,7 +112,11 @@ def _resolve_socket_path(socket_path: Path | None) -> Path:
 async def _establish_rpc_connection(
     path: Path,
 ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
-    """Ensure the daemon is running and open a Unix socket connection."""
+    """Ensure the daemon is running and open a Unix socket connection.
+
+    Raises:
+        typer.Exit: If the daemon fails to start or the Unix socket cannot be opened.
+    """
     try:
         await ensure_daemon_running(path)
     except DaemonStartError as exc:
@@ -132,7 +141,10 @@ async def _execute_rpc_request(
     try:
         writer.write(msjson.encode({"method": method, "params": params or {}}) + b"\n")
         await writer.drain()
-        writer.write_eof()
+        with contextlib.suppress(
+            AttributeError, NotImplementedError
+        ):  # pragma: no cover - transport-specific
+            writer.write_eof()
         error = await _stream_response(reader, stdout)
     finally:
         writer.close()

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -48,7 +48,10 @@ def test_run_rpc_reports_error(
     """_run_rpc should convert exceptions into user-friendly exits."""
 
     def fake_run(func, method, params=None):
-        raise RuntimeError("boom")
+        class FakeRunError(RuntimeError):
+            """Test-only error to simulate RPC failure."""
+
+        raise FakeRunError("boom")
 
     monkeypatch.setattr(cli.anyio, "run", fake_run)
 
@@ -163,7 +166,10 @@ def test_cli_onboard_project_reports_error(
     """onboard-project surfaces RPC errors."""
 
     def fake_run(func, method, params=None):
-        raise RuntimeError("boom")
+        class FakeRunError(RuntimeError):
+            """Test-only error to simulate RPC failure."""
+
+        raise FakeRunError("boom")
 
     monkeypatch.setattr(cli.anyio, "run", fake_run)
 

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -278,8 +278,7 @@ async def test_execute_rpc_request(monkeypatch: pytest.MonkeyPatch) -> None:
     error = await client._execute_rpc_request(
         reader,
         typ.cast("asyncio.StreamWriter", writer),
-        "m",
-        None,
+        client.RPCRequest(method="m"),
         stdout,
     )
     assert error

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -191,8 +191,10 @@ async def test_establish_rpc_connection_daemon_error(
         raise client.DaemonStartError()
 
     monkeypatch.setattr(client, "ensure_daemon_running", fail)
-    with pytest.raises(typer.Exit):
+    with pytest.raises(typer.Exit) as excinfo:
         await client._establish_rpc_connection(Path("x.sock"))
+    assert isinstance(excinfo.value, typer.Exit)
+    assert excinfo.value.exit_code == 1
     assert "Could not ensure daemon is running" in capsys.readouterr().err
 
 
@@ -215,8 +217,10 @@ async def test_establish_rpc_connection_connect_error(
 
     monkeypatch.setattr(client, "ensure_daemon_running", succeed)
     monkeypatch.setattr(asyncio, "open_unix_connection", connect)
-    with pytest.raises(typer.Exit):
+    with pytest.raises(typer.Exit) as excinfo:
         await client._establish_rpc_connection(Path("x.sock"))
+    assert isinstance(excinfo.value, typer.Exit)
+    assert excinfo.value.exit_code == 1
     assert "Failed to connect to daemon" in capsys.readouterr().err
 
 
@@ -236,10 +240,7 @@ async def test_establish_rpc_connection_success(
 
     monkeypatch.setattr(client, "ensure_daemon_running", succeed)
     monkeypatch.setattr(asyncio, "open_unix_connection", connect)
-    assert await client._establish_rpc_connection(Path("x.sock")) == (
-        typ.cast("asyncio.StreamReader", reader),
-        typ.cast("asyncio.StreamWriter", writer),
-    )
+    assert await client._establish_rpc_connection(Path("x.sock")) == (reader, writer)
 
 
 class _DummyWriter:
@@ -283,3 +284,5 @@ async def test_execute_rpc_request(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert error
     assert writer.closed
+    # Ensure the JSON-RPC line was encoded and framed as expected
+    assert writer.written == [msjson.encode({"method": "m", "params": {}}) + b"\n"]

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import msgspec.json as msjson
 import pytest
-import typer
 
 from weaver import client
 from weaver.errors import DependencyErrorCode
@@ -184,23 +183,20 @@ def test_resolve_socket_path_discover(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.anyio
 async def test_establish_rpc_connection_daemon_error(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def fail(path: Path) -> None:  # pragma: no cover - stub
         await asyncio.sleep(0)
-        raise client.DaemonStartError()
+        raise client.DaemonStartError(path, client.STARTUP_TIMEOUT_SECS)
 
     monkeypatch.setattr(client, "ensure_daemon_running", fail)
-    with pytest.raises(typer.Exit) as excinfo:
+    with pytest.raises(client.DaemonStartError):
         await client._establish_rpc_connection(Path("x.sock"))
-    assert isinstance(excinfo.value, typer.Exit)
-    assert excinfo.value.exit_code == 1
-    assert "Could not ensure daemon is running" in capsys.readouterr().err
 
 
 @pytest.mark.anyio
 async def test_establish_rpc_connection_connect_error(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def succeed(path: Path) -> None:
         await asyncio.sleep(0)
@@ -217,11 +213,8 @@ async def test_establish_rpc_connection_connect_error(
 
     monkeypatch.setattr(client, "ensure_daemon_running", succeed)
     monkeypatch.setattr(asyncio, "open_unix_connection", connect)
-    with pytest.raises(typer.Exit) as excinfo:
+    with pytest.raises(ConnectError):
         await client._establish_rpc_connection(Path("x.sock"))
-    assert isinstance(excinfo.value, typer.Exit)
-    assert excinfo.value.exit_code == 1
-    assert "Failed to connect to daemon" in capsys.readouterr().err
 
 
 @pytest.mark.anyio

--- a/weaver/unittests/test_client.py
+++ b/weaver/unittests/test_client.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import msgspec.json as msjson
 import pytest
+import typer
 
 from weaver import client
 from weaver.errors import DependencyErrorCode
@@ -168,3 +169,117 @@ def test_process_response_line_buffered_stdout() -> None:
     assert not client._process_response_line(line, out)
     out.flush()
     assert buf.getvalue() == line
+
+
+def test_resolve_socket_path_passthrough() -> None:
+    path = Path("test.sock")
+    assert client._resolve_socket_path(path) == path
+
+
+def test_resolve_socket_path_discover(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = Path("discover.sock")
+    monkeypatch.setattr(client, "discover_socket", lambda: expected)
+    assert client._resolve_socket_path(None) == expected
+
+
+@pytest.mark.anyio
+async def test_establish_rpc_connection_daemon_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def fail(path: Path) -> None:  # pragma: no cover - stub
+        await asyncio.sleep(0)
+        raise client.DaemonStartError()
+
+    monkeypatch.setattr(client, "ensure_daemon_running", fail)
+    with pytest.raises(typer.Exit):
+        await client._establish_rpc_connection(Path("x.sock"))
+    assert "Could not ensure daemon is running" in capsys.readouterr().err
+
+
+@pytest.mark.anyio
+async def test_establish_rpc_connection_connect_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def succeed(path: Path) -> None:
+        await asyncio.sleep(0)
+
+    class ConnectError(OSError):
+        """Test-only error to simulate socket failure."""
+
+        def __init__(self) -> None:
+            super().__init__("no socket")
+
+    async def connect(path: str) -> None:  # pragma: no cover - stub
+        await asyncio.sleep(0)
+        raise ConnectError()
+
+    monkeypatch.setattr(client, "ensure_daemon_running", succeed)
+    monkeypatch.setattr(asyncio, "open_unix_connection", connect)
+    with pytest.raises(typer.Exit):
+        await client._establish_rpc_connection(Path("x.sock"))
+    assert "Failed to connect to daemon" in capsys.readouterr().err
+
+
+@pytest.mark.anyio
+async def test_establish_rpc_connection_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def succeed(path: Path) -> None:
+        await asyncio.sleep(0)
+
+    reader = typ.cast("asyncio.StreamReader", object())
+    writer = typ.cast("asyncio.StreamWriter", object())
+
+    async def connect(path: str) -> tuple[object, object]:  # pragma: no cover - stub
+        await asyncio.sleep(0)
+        return reader, writer
+
+    monkeypatch.setattr(client, "ensure_daemon_running", succeed)
+    monkeypatch.setattr(asyncio, "open_unix_connection", connect)
+    assert await client._establish_rpc_connection(Path("x.sock")) == (
+        typ.cast("asyncio.StreamReader", reader),
+        typ.cast("asyncio.StreamWriter", writer),
+    )
+
+
+class _DummyWriter:
+    def __init__(self) -> None:
+        self.closed = False
+        self.written: list[bytes] = []
+
+    def write(self, data: bytes) -> None:  # pragma: no cover - simple
+        self.written.append(data)
+
+    async def drain(self) -> None:  # pragma: no cover - simple
+        return None
+
+    def write_eof(self) -> None:  # pragma: no cover - simple
+        return None
+
+    def close(self) -> None:  # pragma: no cover - simple
+        self.closed = True
+
+    async def wait_closed(self) -> None:  # pragma: no cover - simple
+        return None
+
+
+@pytest.mark.anyio
+async def test_execute_rpc_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    writer = _DummyWriter()
+    reader = typ.cast("asyncio.StreamReader", object())
+    stdout = StringIO()
+
+    async def stream(_: asyncio.StreamReader, __: typ.TextIO) -> bool:
+        await asyncio.sleep(0)
+        return True
+
+    monkeypatch.setattr(client, "_stream_response", stream)
+    error = await client._execute_rpc_request(
+        reader,
+        typ.cast("asyncio.StreamWriter", writer),
+        "m",
+        None,
+        stdout,
+    )
+    assert error
+    assert writer.closed

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -167,11 +167,16 @@ def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolInstance:
 
     Raises
     ------
-    RuntimeError
-        If the tool class is not found, not callable or ``tool_attr`` is an
-        unknown string.
-    TypeError
+    SerenaAgentNotFoundError
+        If the Serena optional dependency is missing.
+    UnknownSerenaToolError
+        If ``tool_attr`` is an unknown string.
+    ToolAttrTypeError
         If ``tool_attr`` is neither ``SerenaTool`` nor ``str``.
+    ToolClassNotFoundError
+        If the tool class is not found.
+    ToolClassNotCallableError
+        If the tool class is not callable.
     """
     wf_tools, prompt_mod = _load_serena_modules()
     name = _resolve_tool_name(tool_attr)
@@ -212,7 +217,9 @@ def _import_serena_module(module_name: str) -> ModuleType:
     try:
         return import_module(module_name)
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        if getattr(exc, "name", "") and str(exc.name).startswith("serena"):
+        if module_name.startswith("serena") or (
+            getattr(exc, "name", "") and str(exc.name).startswith("serena")
+        ):
             raise SerenaAgentNotFoundError() from exc
         raise
 

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -212,14 +212,28 @@ def _resolve_string_tool_name(tool_name: str) -> str:
     raise UnknownSerenaToolError(tool_name, valid)
 
 
+def _is_serena_related_error(module_name: str, exc: ModuleNotFoundError) -> bool:
+    """Return ``True`` if ``exc`` indicates a Serena import failure.
+
+    A ModuleNotFoundError is considered Serena-related when either the
+    requested module name or the exception's ``name`` attribute begins with
+    ``"serena"``. This helps distinguish missing optional dependencies from
+    unrelated import errors.
+    """
+
+    requested_module_is_serena = module_name.startswith("serena")
+    exc_name = getattr(exc, "name", "")
+    exc_has_name = bool(exc_name)
+    exc_name_is_serena = exc_has_name and str(exc_name).startswith("serena")
+    return requested_module_is_serena or exc_name_is_serena
+
+
 def _import_serena_module(module_name: str) -> ModuleType:
     """Import a Serena module with consistent error handling."""
     try:
         return import_module(module_name)
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
-        if module_name.startswith("serena") or (
-            getattr(exc, "name", "") and str(exc.name).startswith("serena")
-        ):
+        if _is_serena_related_error(module_name, exc):
             raise SerenaAgentNotFoundError() from exc
         raise
 

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -11,6 +11,7 @@ from importlib import import_module, invalidate_caches
 # pyright: reportMissingImports=false  # Serena optional dependency
 
 if typ.TYPE_CHECKING:  # pragma: no cover - import-time only
+    import collections.abc as cabc
     from types import ModuleType
 
     from serena.prompt_factory import SerenaPromptFactory
@@ -24,6 +25,61 @@ else:  # pragma: no cover - import-time only
 # We expose it as ``object`` to avoid ``Any`` in the public API while keeping it
 # flexible.
 SerenaToolInstance: typ.TypeAlias = object
+
+
+class SerenaAgentNotFoundError(RuntimeError):
+    """Raised when the optional Serena dependency is missing."""
+
+    def __init__(self) -> None:
+        super().__init__("serena-agent not found")
+
+
+class ToolClassNotFoundError(RuntimeError):
+    """Raised when a workflow tool class cannot be located."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"serena.tools.workflow_tools.{name} not found")
+
+
+class ToolClassNotCallableError(TypeError):
+    """Raised when a workflow tool attribute is not callable."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"serena.tools.workflow_tools.{name} is not callable")
+
+
+class PromptFactoryError(TypeError):
+    """Raised when ``SerenaPromptFactory`` is missing or invalid."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "serena.prompt_factory.SerenaPromptFactory not found or not a type",
+        )
+
+
+class ToolInstantiationError(RuntimeError):
+    """Raised when a tool fails to instantiate with the agent."""
+
+    def __init__(self, name: str, exc: Exception) -> None:
+        super().__init__(
+            f"Failed to instantiate serena.tools.workflow_tools.{name}: {exc}",
+        )
+
+
+class ToolAttrTypeError(TypeError):
+    """Raised when ``tool_attr`` is neither ``SerenaTool`` nor ``str``."""
+
+    def __init__(self) -> None:
+        super().__init__("tool_attr must be SerenaTool or str")
+
+
+class UnknownSerenaToolError(RuntimeError):
+    """Raised when a requested Serena tool does not exist."""
+
+    def __init__(self, tool_name: str, valid: cabc.Collection[str]) -> None:
+        super().__init__(
+            f"Unknown Serena tool '{tool_name}'. Expected one of: {', '.join(valid)}",
+        )
 
 
 class SerenaTool(enum.StrEnum):
@@ -67,9 +123,9 @@ def _validate_and_get_tool_class(wf_tools: ModuleType, name: str) -> typ.Any:
 
     tool_cls = getattr(wf_tools, name, None)
     if tool_cls is None:
-        raise RuntimeError(f"serena.tools.workflow_tools.{name} not found")
+        raise ToolClassNotFoundError(name)
     if not callable(tool_cls):
-        raise RuntimeError(f"serena.tools.workflow_tools.{name} is not callable")
+        raise ToolClassNotCallableError(name)
     return tool_cls
 
 
@@ -79,9 +135,7 @@ def _create_agent_with_prompt_factory(prompt_mod: ModuleType) -> _BareAgent:
     # Assumption: SerenaPromptFactory can be instantiated without arguments.
     prompt_factory_attr = getattr(prompt_mod, "SerenaPromptFactory", None)
     if not isinstance(prompt_factory_attr, type):
-        raise RuntimeError(
-            "serena.prompt_factory.SerenaPromptFactory not found or not a type",
-        )
+        raise PromptFactoryError()
     prompt_factory_cls = typ.cast("type[SerenaPromptFactory]", prompt_factory_attr)
     return _BareAgent(prompt_factory_cls())
 
@@ -93,10 +147,8 @@ def _instantiate_tool(
 
     try:
         return tool_cls(agent)
-    except Exception as exc:
-        raise RuntimeError(
-            f"Failed to instantiate serena.tools.workflow_tools.{name}: {exc}",
-        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ToolInstantiationError(name, exc) from exc
 
 
 def create_serena_tool(tool_attr: SerenaTool | str) -> SerenaToolInstance:
@@ -138,7 +190,7 @@ def _resolve_tool_name(tool_attr: SerenaTool | str) -> str:
         return tool_attr.value
 
     if not isinstance(tool_attr, str):
-        raise TypeError("tool_attr must be SerenaTool or str")
+        raise ToolAttrTypeError()
 
     return _resolve_string_tool_name(tool_attr)
 
@@ -152,20 +204,16 @@ def _resolve_string_tool_name(tool_name: str) -> str:
     if tool_name in _VALID_TOOL_VALUES:
         return tool_name
     valid = sorted({*_VALID_TOOL_MEMBER_NAMES, *_VALID_TOOL_VALUES})
-    raise RuntimeError(
-        f"Unknown Serena tool '{tool_name}'. Expected one of: {', '.join(valid)}"
-    )
+    raise UnknownSerenaToolError(tool_name, valid)
 
 
 def _import_serena_module(module_name: str) -> ModuleType:
     """Import a Serena module with consistent error handling."""
-
-    msg = "serena-agent is required; install it via 'uv add serena-agent'."
     try:
         return import_module(module_name)
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
         if getattr(exc, "name", "") and str(exc.name).startswith("serena"):
-            raise RuntimeError(msg) from exc
+            raise SerenaAgentNotFoundError() from exc
         raise
 
 

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -79,9 +79,10 @@ class ReferenceLookupError(RuntimeError):
 class InvalidPositionError(ValueError):
     """Raised when a line or character index is negative."""
 
-    def __init__(self) -> None:
+    def __init__(self, line: int, char: int) -> None:
         super().__init__(
-            "line and character must be non-negative (0-indexed, UTF-16 code units)",
+            f"line and character must be non-negative (0-indexed, UTF-16 code units); "
+            f"got line={line}, char={char}",
         )
 
 
@@ -262,7 +263,7 @@ async def handle_get_definition(
     """Yield symbol definitions for a 0-indexed UTF-16 line/character."""
 
     if line < 0 or char < 0:  # basic input validation
-        raise InvalidPositionError()
+        raise InvalidPositionError(line, char)
 
     tool = typ.cast(
         typ.Any,  # noqa: TC006

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -238,10 +238,8 @@ async def handle_list_diagnostics(
 
     # Prepare filters for case- and path-insensitive comparison
     norm_severity, norm_files = _normalize_filters(severity, files)
+    tool = typ.cast("_DiagnosticsTool", create_serena_tool(SerenaTool.LIST_DIAGNOSTICS))
     try:
-        tool = typ.cast(
-            "_DiagnosticsTool", create_serena_tool(SerenaTool.LIST_DIAGNOSTICS)
-        )
         data = await asyncio.to_thread(tool.list_diagnostics)
     except (asyncio.CancelledError, KeyboardInterrupt):  # propagate cancels
         raise

--- a/weaverd/server.py
+++ b/weaverd/server.py
@@ -41,12 +41,56 @@ logger = logging.getLogger(__name__)
 HANDLERS: list[tuple[str, Handler]] = []
 
 
+class HandlerRegistrationError(ValueError):
+    """Raised when registering the same RPC handler twice."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"handler '{name}' already registered")
+
+
+class OnboardingError(RuntimeError):
+    """Raised when onboarding a project fails unexpectedly."""
+
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(f"Onboarding failed: {exc}")
+
+
+class DiagnosticsError(RuntimeError):
+    """Raised when listing diagnostics fails."""
+
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(f"Diagnostics failed: {exc}")
+
+
+class DefinitionLookupError(RuntimeError):
+    """Raised when looking up a symbol definition fails."""
+
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(f"Definition lookup failed: {exc}")
+
+
+class ReferenceLookupError(RuntimeError):
+    """Raised when looking up symbol references fails."""
+
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(f"Reference lookup failed: {exc}")
+
+
+class InvalidPositionError(ValueError):
+    """Raised when a line or character index is negative."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "line and character must be non-negative (0-indexed, UTF-16 code units)",
+        )
+
+
 def rpc_handler(name: str) -> typ.Callable[[Handler], Handler]:
     """Register ``func`` as an RPC handler with ``name``."""
 
     def decorator(func: Handler) -> Handler:
         if any(existing == name for existing, _ in HANDLERS):
-            raise ValueError(f"handler '{name}' already registered")
+            raise HandlerRegistrationError(name)
         HANDLERS.append((name, func))
         return func
 
@@ -140,7 +184,7 @@ async def handle_onboard_project() -> OnboardingReport:
     except (asyncio.CancelledError, KeyboardInterrupt):  # propagate cancels
         raise
     except Exception as exc:  # pragma: no cover - unexpected failures
-        raise RuntimeError(f"Onboarding failed: {exc}") from exc
+        raise OnboardingError(exc) from exc
     return OnboardingReport(details=details)
 
 
@@ -201,7 +245,7 @@ async def handle_list_diagnostics(
     except (asyncio.CancelledError, KeyboardInterrupt):  # propagate cancels
         raise
     except Exception as exc:
-        raise RuntimeError(f"Diagnostics failed: {exc}") from exc
+        raise DiagnosticsError(exc) from exc
     for item in data:
         diag = ms.convert(item, Diagnostic)
         diag_severity, diag_file = _normalize_diagnostic_data(diag)
@@ -218,9 +262,7 @@ async def handle_get_definition(
     """Yield symbol definitions for a 0-indexed UTF-16 line/character."""
 
     if line < 0 or char < 0:  # basic input validation
-        raise ValueError(
-            "line and character must be non-negative (0-indexed, UTF-16 code units)"
-        )
+        raise InvalidPositionError()
 
     tool = typ.cast(
         typ.Any,  # noqa: TC006
@@ -231,7 +273,7 @@ async def handle_get_definition(
             tool.get_definition, file=file, line=line, char=char
         )
     except RuntimeError as exc:
-        raise RuntimeError(f"Definition lookup failed: {exc}") from exc
+        raise DefinitionLookupError(exc) from exc
     for item in data:
         yield ms.convert(item, Symbol)
 
@@ -259,7 +301,7 @@ async def handle_list_references(
             include_definition=include_definition,
         )
     except RuntimeError as exc:
-        raise RuntimeError(f"Reference lookup failed: {exc}") from exc
+        raise ReferenceLookupError(exc) from exc
     for item in data:
         yield ms.convert(item, Reference)
 

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -7,7 +7,7 @@ import pytest
 from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Symbol
 from weaverd import server
-from weaverd.serena_tools import SerenaTool
+from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
 
 try:
     _anext = builtins.anext  # type: ignore[attr-defined]
@@ -171,11 +171,11 @@ async def test_handle_get_definition_missing_dependency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def raise_error(_: SerenaTool) -> None:
-        raise RuntimeError("serena-agent not found")
+        raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
-    with pytest.raises(RuntimeError, match="serena-agent not found"):
+    with pytest.raises(SerenaAgentNotFoundError, match="serena-agent not found"):
         await anext(server.handle_get_definition("foo.py", 1, 0))
 
 

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -1,5 +1,6 @@
 import builtins
 import collections.abc as cabc
+import typing as typ
 from dataclasses import dataclass  # noqa: ICN003 -- simpler decorator usage
 
 import pytest
@@ -72,7 +73,9 @@ def _setup_and_call_get_definition(
     return server.handle_get_definition(position.file, position.line, position.char)
 
 
-async def _collect_symbols_from_results(results, expected_count: int) -> list[Symbol]:
+async def _collect_symbols_from_results(
+    results: cabc.AsyncIterator[Symbol], expected_count: int
+) -> list[Symbol]:
     """Helper to collect symbols from async iterator and verify count."""
     symbols: list[Symbol] = []
     try:
@@ -170,7 +173,7 @@ async def test_handle_get_definition_multiple_symbols(
 async def test_handle_get_definition_missing_dependency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_error(_: SerenaTool) -> None:
+    def raise_error(_: SerenaTool) -> typ.NoReturn:
         raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -12,7 +12,12 @@ from weaver_schemas.error import SchemaError
 from weaver_schemas.primitives import Location, Position, Range
 from weaverd import server
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import SerenaTool
+from weaverd.serena_tools import (
+    SerenaAgentNotFoundError,
+    SerenaTool,
+    ToolClassNotCallableError,
+    ToolClassNotFoundError,
+)
 from weaverd.server import start_server
 
 if typ.TYPE_CHECKING:
@@ -106,7 +111,7 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(serena_tools, "import_module", fake_import)
     serena_tools.clear_serena_imports()
 
-    with pytest.raises(RuntimeError, match=r"workflow_tools.OnboardingTool"):
+    with pytest.raises(ToolClassNotFoundError, match=r"workflow_tools.OnboardingTool"):
         serena_tools.create_serena_tool(SerenaTool.ONBOARDING)
     serena_tools.clear_serena_imports()
 
@@ -126,7 +131,7 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(serena_tools, "import_module", fake_import_noncallable)
     serena_tools.clear_serena_imports()
-    with pytest.raises(RuntimeError, match="not callable"):
+    with pytest.raises(ToolClassNotCallableError, match="not callable"):
         serena_tools.create_serena_tool(SerenaTool.ONBOARDING)
     serena_tools.clear_serena_imports()
 
@@ -157,7 +162,7 @@ async def test_missing_diagnostics_dependency(
     dispatcher = RPCDispatcher()
 
     def raise_error(_: SerenaTool) -> StubTool:
-        raise RuntimeError("serena-agent not found")
+        raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -59,7 +59,10 @@ async def test_onboard_failure(tmp_path: Path) -> None:
 
     class FailingTool:
         def apply(self) -> str:  # pragma: no cover - stub
-            raise RuntimeError("boom")
+            class OnboardToolError(RuntimeError):
+                """Test-only error to simulate onboarding failure."""
+
+            raise OnboardToolError("boom")
 
     @dispatcher.register("onboard-project")
     def onboard() -> OnboardingReport:  # pyright: ignore[reportUnusedFunction]

--- a/weaverd/unittests/test_onboard.py
+++ b/weaverd/unittests/test_onboard.py
@@ -11,7 +11,11 @@ import pytest
 
 from weaver_schemas.reports import OnboardingReport
 from weaverd.rpc import RPCDispatcher
-from weaverd.serena_tools import SerenaTool, create_serena_tool
+from weaverd.serena_tools import (
+    SerenaTool,
+    UnknownSerenaToolError,
+    create_serena_tool,
+)
 from weaverd.server import start_server
 
 
@@ -94,5 +98,5 @@ async def test_onboard_failure(tmp_path: Path) -> None:
 def test_create_serena_tool_with_invalid_tool_name() -> None:
     """create_serena_tool should raise for unknown tools."""
 
-    with pytest.raises(RuntimeError, match="NonExistentTool"):
+    with pytest.raises(UnknownSerenaToolError, match="NonExistentTool"):
         create_serena_tool("NonExistentTool")

--- a/weaverd/unittests/test_references.py
+++ b/weaverd/unittests/test_references.py
@@ -5,7 +5,8 @@ import pytest
 from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Reference
 from weaverd import server
-from weaverd.serena_tools import SerenaTool
+from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
+from weaverd.server import ReferenceLookupError
 
 
 class StubTool:
@@ -56,11 +57,11 @@ async def test_handle_list_references_missing_dependency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def raise_error(_: SerenaTool) -> None:
-        raise RuntimeError("serena-agent not found")
+        raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
 
-    with pytest.raises(RuntimeError, match="serena-agent not found"):
+    with pytest.raises(SerenaAgentNotFoundError, match="serena-agent not found"):
         await builtins.anext(server.handle_list_references("foo.py", 1, 0))
 
 
@@ -76,5 +77,5 @@ async def test_handle_list_references_wraps_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(server, "create_serena_tool", lambda _: FailingTool())
-    with pytest.raises(RuntimeError, match="Reference lookup failed: boom"):
+    with pytest.raises(ReferenceLookupError, match="Reference lookup failed: boom"):
         await builtins.anext(server.handle_list_references("foo.py", 1, 0))

--- a/weaverd/unittests/test_references.py
+++ b/weaverd/unittests/test_references.py
@@ -1,4 +1,5 @@
 import builtins
+import typing as typ
 
 import pytest
 
@@ -56,7 +57,7 @@ async def test_handle_list_references_no_results(
 async def test_handle_list_references_missing_dependency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_error(_: SerenaTool) -> None:
+    def raise_error(_: SerenaTool) -> typ.NoReturn:
         raise SerenaAgentNotFoundError()
 
     monkeypatch.setattr(server, "create_serena_tool", raise_error)
@@ -69,7 +70,10 @@ class FailingTool:
     def list_references(
         self, *, file: str, line: int, char: int, include_definition: bool = False
     ) -> list[Reference]:
-        raise RuntimeError("boom")
+        class ListReferencesToolError(RuntimeError):
+            """Test-only error to simulate reference lookup failure."""
+
+        raise ListReferencesToolError("boom")
 
 
 @pytest.mark.anyio

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -104,7 +104,11 @@ async def test_dispatcher_streams_midstream_error() -> None:
 
     def boom() -> typ.Iterator[int]:
         yield 1
-        raise RuntimeError("boom")
+
+        class BoomError(RuntimeError):
+            """Test-only error to simulate streaming failure."""
+
+        raise BoomError("boom")
 
     @dispatcher.register("boom")
     def handler() -> typ.Iterable[int]:  # pyright: ignore[reportUnusedFunction]

--- a/weaverd/unittests/test_serena_tools.py
+++ b/weaverd/unittests/test_serena_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from weaverd.serena_tools import (
     SerenaTool,
+    UnknownSerenaToolError,
     _is_serena_related_error,
     _resolve_string_tool_name,
     _resolve_tool_name,
@@ -24,7 +25,7 @@ def test_resolve_string_tool_name_success(input_name: str, expected: str) -> Non
 
 
 def test_resolve_string_tool_name_unknown() -> None:
-    with pytest.raises(RuntimeError, match="Unknown Serena tool 'Nope'"):
+    with pytest.raises(UnknownSerenaToolError, match="Unknown Serena tool 'Nope'"):
         _resolve_string_tool_name("Nope")
 
 

--- a/weaverd/unittests/test_serena_tools.py
+++ b/weaverd/unittests/test_serena_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from weaverd.serena_tools import (
     SerenaTool,
+    _is_serena_related_error,
     _resolve_string_tool_name,
     _resolve_tool_name,
 )
@@ -34,3 +35,20 @@ def test_resolve_tool_name_type_error() -> None:
 
 def test_resolve_tool_name_from_enum() -> None:
     assert _resolve_tool_name(SerenaTool.ONBOARDING) == "OnboardingTool"
+
+
+def test_is_serena_related_error_by_module_name() -> None:
+    exc = ModuleNotFoundError()
+    assert _is_serena_related_error("serena.fake", exc) is True
+
+
+def test_is_serena_related_error_by_exc_name() -> None:
+    exc = ModuleNotFoundError()
+    exc.name = "serena.fake"
+    assert _is_serena_related_error("other", exc) is True
+
+
+def test_is_serena_related_error_false() -> None:
+    exc = ModuleNotFoundError()
+    exc.name = "other"
+    assert _is_serena_related_error("random", exc) is False


### PR DESCRIPTION
## Summary
- enable TRY checks in ruff configuration
- replace generic RuntimeError strings with custom exceptions across client and server
- update tests to use new exception types

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a67ba7de64832290eeb23822c28904

## Summary by Sourcery

Enforce TRY linting and improve error handling by defining and using custom exception classes in place of generic errors across the codebase, and update tests to expect these new exception types.

Enhancements:
- Introduce custom exception classes in serena_tools, server, client, and test utilities for more precise error reporting
- Replace all generic RuntimeError, TypeError, ValueError, and TimeoutError raises with the corresponding custom exceptions

Build:
- Enable the TRY rule in the Ruff configuration for exception handling best practices

Tests:
- Update unit and feature tests to assert on the new custom exception types instead of generic ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Clearer, more specific user-facing error types for daemon startup, onboarding, diagnostics, definition/reference lookup, and external tool integration.

- **Bug Fixes**
  - Improved daemon/socket readiness handling with clearer exit/reporting when connections or startup fail.

- **Tests**
  - Updated and added tests to cover new error signaling, client RPC connection/startup behavior, and Serena integration edge cases.

- **Chores**
  - Project metadata, packaging and dev-tool configs updated (author, Python 3.11 target, dev deps, lint/type settings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->