### PR TITLE
Enforce function annotations

### DIFF
--- a/features/steps/test_list_diagnostics.py
+++ b/features/steps/test_list_diagnostics.py
@@ -1,18 +1,24 @@
+from __future__ import annotations
+
+import types as _types
 import typing as typ
 
 import anyio
 import msgspec as ms
-import pytest
+
+if typ.TYPE_CHECKING:
+    import pytest
+
+    from features.types import Context
+    from weaverd.rpc import RPCDispatcher
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 
-from features.types import Context
 from weaver import client
 from weaver.cli import app
 from weaver_schemas.diagnostics import Diagnostic
 from weaver_schemas.primitives import Location, Position, Range
 from weaverd import serena_tools, server
-from weaverd.rpc import RPCDispatcher
 from weaverd.serena_tools import SerenaTool, ToolClassNotFoundError
 
 from .helpers import raise_serena_agent_not_found
@@ -144,21 +150,22 @@ def test_create_serena_tool_string_enum_equivalence(
 ) -> None:
     """create_serena_tool accepts both enum and string names."""
 
-    class ToolsMod:  # pragma: no cover - simple stub
-        class ListDiagnosticsTool:  # pragma: no cover - simple stub
-            def __init__(self, _: typ.Any) -> None:  # pragma: no cover - stub
-                pass
+    class _ListDiagnosticsTool:  # pragma: no cover - simple stub
+        def __init__(self, _: object) -> None:  # pragma: no cover - stub
+            pass
 
-    class PromptMod:  # pragma: no cover - simple stub
-        class SerenaPromptFactory:  # pragma: no cover - simple stub
-            def __call__(self) -> None:  # pragma: no cover - stub
-                return None
+    class _SerenaPromptFactory:  # pragma: no cover - simple stub
+        def __call__(self) -> None:  # pragma: no cover - stub
+            return None
 
-    def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
+    def fake_import(name: str) -> _types.ModuleType:  # pragma: no cover - simple stub
+        mod = _types.ModuleType(name)
         if name == "serena.tools.workflow_tools":
-            return ToolsMod
+            mod.ListDiagnosticsTool = _ListDiagnosticsTool  # type: ignore[attr-defined]
+            return mod
         if name == "serena.prompt_factory":
-            return PromptMod
+            mod.SerenaPromptFactory = _SerenaPromptFactory  # type: ignore[attr-defined]
+            return mod
         raise ModuleNotFoundError
 
     monkeypatch.setattr(serena_tools, "import_module", fake_import)

--- a/features/steps/test_onboard_project.py
+++ b/features/steps/test_onboard_project.py
@@ -1,17 +1,24 @@
+from __future__ import annotations
+
 import json
 import os
 import typing as typ
-from pathlib import Path
 
 import anyio
 import msgspec as ms
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+    from features.types import Context
+    from weaverd.rpc import RPCDispatcher
 from pytest_bdd import given, scenarios, then, when
 from typer.testing import CliRunner
 
-from features.types import Context
 from weaver.cli import app
 from weaver_schemas.reports import OnboardingReport
-from weaverd.rpc import RPCDispatcher
 from weaverd.serena_tools import (
     SerenaAgentNotFoundError,
     SerenaTool,
@@ -36,7 +43,7 @@ def runtime_dir(runtime_dir: Context) -> Context:
 
 
 @given("an invalid project structure")
-def invalid_project(context: Context, monkeypatch) -> None:
+def invalid_project(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
     async def fail_spawn(_: Path) -> None:  # pragma: no cover - stub
         await anyio.sleep(0)
 
@@ -44,7 +51,7 @@ def invalid_project(context: Context, monkeypatch) -> None:
 
 
 @given("the server is unavailable")
-def server_unavailable(context: Context, monkeypatch) -> None:
+def server_unavailable(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
     async def noop(_: Path) -> None:  # pragma: no cover - stub
         await anyio.sleep(0)
 
@@ -64,7 +71,7 @@ def server_malformed(context: Context) -> None:
 
 
 @given("the onboarding tool raises an error")
-def tool_error(context: Context, monkeypatch) -> None:
+def tool_error(context: Context, monkeypatch: pytest.MonkeyPatch) -> None:
     def setup(dispatcher: RPCDispatcher) -> None:
         class FailingTool:
             def apply(self) -> str:  # pragma: no cover - stub
@@ -82,7 +89,7 @@ def tool_error(context: Context, monkeypatch) -> None:
 
 
 @given("serena-agent is missing")
-def missing_dependency(monkeypatch):
+def missing_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("WEAVER_TEST_MISSING_SERENA", "1")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ select = [
     "DTZ",      # require strict timezone manipulation with datetime
     "FBT",      # detect boolean traps
     "N",        # enforce naming conventions, e.g. ClassName vs function_name
+    "ANN",      # Function/method annotations
     "FURB",      # Refurb-style suggestions
     "B",         # Bugbear warnings
     "TRY",      # Exception handling best practices

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -7,7 +7,7 @@ import anyio
 import typer
 
 from . import pure
-from .client import rpc_call
+from .client import JSONObject, rpc_call
 from .sockets import can_connect
 
 app = typer.Typer(name="weaver")
@@ -42,7 +42,7 @@ def _make_stub(name: str) -> typ.Callable[[], None]:
     return command
 
 
-def _run_rpc(method: str, params: dict | None = None) -> None:
+def _run_rpc(method: str, params: JSONObject | None = None) -> None:
     """Execute an RPC request and handle failures uniformly."""
     try:
         anyio.run(rpc_call, method, params)
@@ -70,7 +70,7 @@ def list_diagnostics(
     files: list[Path] = typer.Argument(None, metavar="[FILES...]"),  # noqa: B008
 ) -> None:
     """Stream diagnostics for the workspace."""
-    params: dict[str, typ.Any] = {}
+    params: JSONObject = {}
     if severity:
         params["severity"] = severity
     if files:
@@ -109,7 +109,7 @@ def get_definition(
         0-indexed character offset within the line.
     """
 
-    params = {"file": str(file), "line": line, "char": char}
+    params: JSONObject = {"file": str(file), "line": line, "char": char}
     _run_rpc("get-definition", params)
 
 
@@ -131,7 +131,7 @@ def list_references(
 ) -> None:
     """Locate all references to the symbol at the given position."""
 
-    params: dict[str, typ.Any] = {"file": str(file), "line": line, "char": char}
+    params: JSONObject = {"file": str(file), "line": line, "char": char}
     if include_definition:
         params["include_definition"] = True
     _run_rpc("list-references", params)

--- a/weaver/unittests/test_cli.py
+++ b/weaver/unittests/test_cli.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import dataclasses
-import pathlib
 import typing as typ
 
 import pytest
@@ -7,6 +8,37 @@ import typer
 from typer.testing import CliRunner
 
 import weaver.cli as cli
+from weaver.client import JSONObject
+
+if typ.TYPE_CHECKING:
+    import pathlib
+
+RPCCall: typ.TypeAlias = typ.Callable[[str, JSONObject | None], object]
+RunStub: typ.TypeAlias = typ.Callable[[RPCCall, str, JSONObject | None], None]
+
+
+def make_run_stub(
+    called: dict[str, object] | None = None,
+    error: BaseException | None = None,
+) -> RunStub:
+    """Return an ``anyio.run`` stand-in.
+
+    The stub avoids actual I/O by either recording invocation parameters or
+    raising a provided error. Tests can reuse this helper to minimise boilerplate
+    while validating how CLI commands interact with the RPC layer.
+    """
+
+    def _run(
+        func: RPCCall,
+        method: str,
+        params: JSONObject | None = None,
+    ) -> None:
+        if called is not None:
+            called.update({"func": func, "method": method, "params": params})
+        if error is not None:
+            raise error
+
+    return _run
 
 
 def test_cli_hello() -> None:
@@ -27,12 +59,7 @@ def test_cli_check_socket(tmp_path: pathlib.Path) -> None:
 def test_run_rpc_invokes_anyio(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure _run_rpc delegates to anyio.run without I/O."""
     called: dict[str, object] = {}
-
-    def fake_run(func, method, params=None):
-        # The helper should forward rpc_call and user arguments verbatim.
-        called.update({"func": func, "method": method, "params": params})
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    monkeypatch.setattr(cli.anyio, "run", make_run_stub(called))
     cli._run_rpc("test-method", {"a": 1})
 
     assert called == {
@@ -47,13 +74,10 @@ def test_run_rpc_reports_error(
 ) -> None:
     """_run_rpc should convert exceptions into user-friendly exits."""
 
-    def fake_run(func, method, params=None):
-        class FakeRunError(RuntimeError):
-            """Test-only error to simulate RPC failure."""
+    class FakeRunError(RuntimeError):
+        """Test-only error to simulate RPC failure."""
 
-        raise FakeRunError("boom")
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    monkeypatch.setattr(cli.anyio, "run", make_run_stub(error=FakeRunError("boom")))
 
     with pytest.raises(typer.Exit):
         cli._run_rpc("broken")
@@ -66,7 +90,7 @@ class CLITestCase:
     cli_command: str
     rpc_method: str
     args: list[str]
-    params: dict[str, typ.Any] | None
+    params: JSONObject | None
 
 
 @pytest.mark.parametrize(
@@ -93,12 +117,7 @@ def test_cli_commands_use_run_rpc(
 ) -> None:
     """CLI commands use _run_rpc to contact the daemon."""
     called: dict[str, object] = {}
-
-    def fake_run(func, method, params=None):
-        # Avoid network access while verifying parameters.
-        called.update({"func": func, "method": method, "params": params})
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    monkeypatch.setattr(cli.anyio, "run", make_run_stub(called))
 
     runner = CliRunner()
     result = runner.invoke(cli.app, [test_case.cli_command, *test_case.args])
@@ -115,13 +134,8 @@ def test_cli_list_references_include_definition(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """list-references forwards include-definition flag to RPC."""
-
     called: dict[str, object] = {}
-
-    def fake_run(func, method, params=None):
-        called.update({"func": func, "method": method, "params": params})
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    monkeypatch.setattr(cli.anyio, "run", make_run_stub(called))
 
     runner = CliRunner()
     result = runner.invoke(
@@ -146,12 +160,7 @@ def test_cli_get_definition_handles_empty_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """get-definition exits cleanly when the RPC stream is empty."""
-
-    def fake_run(func, method, params=None):
-        # Simulate RPC call producing no output.
-        return None
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    monkeypatch.setattr(cli.anyio, "run", make_run_stub())
 
     runner = CliRunner()
     result = runner.invoke(cli.app, ["get-definition", __file__, "1", "2"])
@@ -165,13 +174,10 @@ def test_cli_onboard_project_reports_error(
 ) -> None:
     """onboard-project surfaces RPC errors."""
 
-    def fake_run(func, method, params=None):
-        class FakeRunError(RuntimeError):
-            """Test-only error to simulate RPC failure."""
+    class FakeRunError(RuntimeError):
+        """Test-only error to simulate RPC failure."""
 
-        raise FakeRunError("boom")
-
-    monkeypatch.setattr(cli.anyio, "run", fake_run)
+    monkeypatch.setattr(cli.anyio, "run", make_run_stub(error=FakeRunError("boom")))
 
     runner = CliRunner()
     result = runner.invoke(cli.app, ["onboard-project"])

--- a/weaverd/rpc.py
+++ b/weaverd/rpc.py
@@ -9,23 +9,24 @@ import msgspec.json as msjson
 
 from weaver_schemas.error import SchemaError
 
-HandlerSync = typ.Callable[..., typ.Any]
-HandlerAsync = typ.Callable[..., typ.Awaitable[typ.Any]]
+if typ.TYPE_CHECKING:
+    from weaver.client import JSONObject
+else:  # pragma: no cover - runtime compatibility
+    JSONObject = dict[str, object]
+
+HandlerSync = typ.Callable[..., object]
+HandlerAsync = typ.Callable[..., typ.Awaitable[object]]
 Handler = HandlerSync | HandlerAsync
 
-ResultProcessor: typ.TypeAlias = (
-    typ.Callable[[bytes | bytearray], typ.AsyncIterator[bytes]]
-    | typ.Callable[[typ.AsyncIterable[typ.Any]], typ.AsyncIterator[bytes]]
-    | typ.Callable[[typ.Iterable[typ.Any]], typ.AsyncIterator[bytes]]
-    | typ.Callable[[typ.Any], typ.AsyncIterator[bytes]]
-)
+Predicate = typ.Callable[[object], bool]
+ResultProcessor = typ.Callable[[object], typ.AsyncIterator[bytes]]
 
 
 class RPCRequest(ms.Struct, frozen=True):
     """JSON-RPC style request."""
 
     method: str
-    params: dict[str, typ.Any] | None = None
+    params: JSONObject | None = None
 
 
 class RPCDispatcher:
@@ -53,13 +54,13 @@ class RPCDispatcher:
 
     async def _execute_handler(
         self, handler: Handler | None, request: RPCRequest
-    ) -> tuple[typ.Any | None, bytes | None]:
+    ) -> tuple[object | None, bytes | None]:
         if handler is None:
             return None, self._encode_error(f"unknown method: {request.method}")
         try:
             result = handler(**(request.params or {}))
             if inspect.isawaitable(result):
-                result = await typ.cast(typ.Awaitable[typ.Any], result)  # noqa: TC006
+                result = await typ.cast(typ.Awaitable[object], result)  # noqa: TC006
         except Exception as exc:  # noqa: BLE001 - ensure structured errors
             return None, self._encode_error(str(exc))
         return result, None
@@ -70,7 +71,7 @@ class RPCDispatcher:
         yield result if isinstance(result, bytes) else bytes(result)
 
     async def _process_async_iterable_result(
-        self, result: typ.AsyncIterable[typ.Any]
+        self, result: typ.AsyncIterable[object]
     ) -> typ.AsyncIterator[bytes]:
         try:
             async for item in result:
@@ -79,7 +80,7 @@ class RPCDispatcher:
             yield self._encode_error(str(exc))
 
     async def _process_sync_iterable_result(
-        self, result: typ.Iterable[typ.Any]
+        self, result: typ.Iterable[object]
     ) -> typ.AsyncIterator[bytes]:
         try:
             for item in result:
@@ -87,23 +88,46 @@ class RPCDispatcher:
         except Exception as exc:  # noqa: BLE001 - ensure structured errors
             yield self._encode_error(str(exc))
 
-    async def _process_single_result(self, result: typ.Any) -> typ.AsyncIterator[bytes]:
+    async def _process_single_result(self, result: object) -> typ.AsyncIterator[bytes]:
         yield msjson.encode(result)
 
-    def _get_result_processor(self, result: typ.Any) -> ResultProcessor:
-        if isinstance(result, (bytes, bytearray)):
-            return self._process_bytes_result
-        if isinstance(result, cabc.AsyncIterable):
-            return self._process_async_iterable_result
-        if isinstance(result, cabc.Iterable) and not isinstance(
-            result, (str, bytes, bytearray)
-        ):
-            return self._process_sync_iterable_result
-        return self._process_single_result
+    @staticmethod
+    def _is_bytes_result(result: object) -> bool:
+        return isinstance(result, (bytes, bytearray))
 
-    async def _process_result(self, result: typ.Any) -> typ.AsyncIterator[bytes]:
-        processor = self._get_result_processor(result)
-        async for chunk in processor(result):
+    @staticmethod
+    def _is_async_iterable_result(result: object) -> bool:
+        return isinstance(result, cabc.AsyncIterable)
+
+    @staticmethod
+    def _is_sync_iterable_result(result: object) -> bool:
+        return isinstance(result, cabc.Iterable) and not isinstance(
+            result, (str, bytes, bytearray, cabc.Mapping)
+        )
+
+    async def _process_result(self, result: object) -> typ.AsyncIterator[bytes]:
+        processor_chain: tuple[tuple[Predicate, ResultProcessor], ...] = (
+            (
+                self._is_bytes_result,
+                typ.cast("ResultProcessor", self._process_bytes_result),
+            ),
+            (
+                self._is_async_iterable_result,
+                typ.cast("ResultProcessor", self._process_async_iterable_result),
+            ),
+            (
+                self._is_sync_iterable_result,
+                typ.cast("ResultProcessor", self._process_sync_iterable_result),
+            ),
+        )
+
+        for predicate, processor in processor_chain:
+            if predicate(result):
+                async for chunk in processor(result):
+                    yield chunk
+                return
+
+        async for chunk in self._process_single_result(result):
             yield chunk
 
     async def handle(self, data: bytes) -> typ.AsyncIterator[bytes]:

--- a/weaverd/serena_tools.py
+++ b/weaverd/serena_tools.py
@@ -42,10 +42,10 @@ class ToolClassNotFoundError(RuntimeError):
 
 
 class ToolClassNotCallableError(TypeError):
-    """Raised when a workflow tool attribute is not callable."""
+    """Raised when a workflow tool attribute is not a class."""
 
     def __init__(self, name: str) -> None:
-        super().__init__(f"serena.tools.workflow_tools.{name} is not callable")
+        super().__init__(f"serena.tools.workflow_tools.{name} is not a class")
 
 
 class PromptFactoryError(TypeError):
@@ -118,15 +118,17 @@ def clear_serena_imports() -> None:
         sys.modules.pop(name, None)
 
 
-def _validate_and_get_tool_class(wf_tools: ModuleType, name: str) -> typ.Any:
-    """Return the workflow tool class, ensuring it exists and is callable."""
+def _validate_and_get_tool_class(wf_tools: ModuleType, name: str) -> type[object]:
+    """Return the workflow tool class, ensuring it exists and is a class."""
 
     tool_cls = getattr(wf_tools, name, None)
     if tool_cls is None:
         raise ToolClassNotFoundError(name)
-    if not callable(tool_cls):
+    # Must be a class.
+    if not isinstance(tool_cls, type):
         raise ToolClassNotCallableError(name)
-    return tool_cls
+    # Help type-checkers: ``tool_cls`` is a class at this point.
+    return typ.cast("type[object]", tool_cls)
 
 
 def _create_agent_with_prompt_factory(prompt_mod: ModuleType) -> _BareAgent:
@@ -141,7 +143,7 @@ def _create_agent_with_prompt_factory(prompt_mod: ModuleType) -> _BareAgent:
 
 
 def _instantiate_tool(
-    tool_cls: typ.Any, agent: _BareAgent, name: str
+    tool_cls: type[object], agent: _BareAgent, name: str
 ) -> SerenaToolInstance:
     """Instantiate ``tool_cls`` with ``agent`` and wrap errors."""
 

--- a/weaverd/unittests/test_definition.py
+++ b/weaverd/unittests/test_definition.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import builtins
-import collections.abc as cabc
 import typing as typ
 from dataclasses import dataclass  # noqa: ICN003 -- simpler decorator usage
 
 import pytest
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
 
 from weaver_schemas.primitives import Location, Position, Range
 from weaver_schemas.references import Symbol
@@ -13,8 +17,9 @@ from weaverd.serena_tools import SerenaAgentNotFoundError, SerenaTool
 try:
     _anext = builtins.anext  # type: ignore[attr-defined]
 except AttributeError:  # Python < 3.10
+    T = typ.TypeVar("T")
 
-    async def _anext(it):
+    async def _anext(it: cabc.AsyncIterator[T]) -> T:
         return await it.__anext__()
 
 

--- a/weaverd/unittests/test_diagnostics.py
+++ b/weaverd/unittests/test_diagnostics.py
@@ -101,7 +101,7 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
             def __call__(self) -> None:  # pragma: no cover - simple stub
                 return None
 
-    def fake_import(name: str) -> typ.Any:  # pragma: no cover - simple stub
+    def fake_import(name: str) -> object:  # pragma: no cover - simple stub
         if name == "serena.tools.workflow_tools":
             return ToolsMod
         if name == "serena.prompt_factory":
@@ -118,7 +118,7 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
     class NonCallableTool:  # pragma: no cover - simple stub
         pass
 
-    def fake_import_noncallable(name: str) -> typ.Any:  # pragma: no cover - stub
+    def fake_import_noncallable(name: str) -> object:  # pragma: no cover - stub
         if name == "serena.tools.workflow_tools":
 
             class Tools:  # pragma: no cover - stub
@@ -131,7 +131,7 @@ def test_unknown_tool_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(serena_tools, "import_module", fake_import_noncallable)
     serena_tools.clear_serena_imports()
-    with pytest.raises(ToolClassNotCallableError, match="not callable"):
+    with pytest.raises(ToolClassNotCallableError, match="not a class"):
         serena_tools.create_serena_tool(SerenaTool.ONBOARDING)
     serena_tools.clear_serena_imports()
 

--- a/weaverd/unittests/test_memory_usage.py
+++ b/weaverd/unittests/test_memory_usage.py
@@ -3,26 +3,30 @@ from __future__ import annotations
 import resource
 import sys
 import types
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    import pytest
 
 from weaverd import server
 
 
-def test_get_rss_mb_linux(monkeypatch) -> None:
+def test_get_rss_mb_linux(monkeypatch: pytest.MonkeyPatch) -> None:
     usage = types.SimpleNamespace(ru_maxrss=2048)
     monkeypatch.setattr(resource, "getrusage", lambda _: usage)
     monkeypatch.setattr(sys, "platform", "linux", raising=False)
     assert server._get_rss_mb() == 2.0
 
 
-def test_get_rss_mb_darwin(monkeypatch) -> None:
+def test_get_rss_mb_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
     usage = types.SimpleNamespace(ru_maxrss=2 * 1024 * 1024)
     monkeypatch.setattr(resource, "getrusage", lambda _: usage)
     monkeypatch.setattr(sys, "platform", "darwin", raising=False)
     assert server._get_rss_mb() == 2.0
 
 
-def test_get_rss_mb_error(monkeypatch) -> None:
-    def raise_error(arg):
+def test_get_rss_mb_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_error(arg: int) -> typ.Never:
         raise OSError()
 
     monkeypatch.setattr(resource, "getrusage", raise_error)

--- a/weaverd/unittests/test_rpc.py
+++ b/weaverd/unittests/test_rpc.py
@@ -99,6 +99,22 @@ async def test_dispatcher_streams_multiple_results() -> None:
 
 
 @pytest.mark.anyio
+async def test_dispatcher_handles_dict_result() -> None:
+    dispatcher = RPCDispatcher()
+
+    @dispatcher.register("mapping")
+    def handler() -> dict[str, bool]:  # pyright: ignore[reportUnusedFunction]
+        return {"ok": True}
+
+    req = msjson.encode({"method": "mapping"})
+    results = dispatcher.handle(req)
+    response = msjson.decode(await builtins.anext(results), type=dict[str, bool])
+    with pytest.raises(StopAsyncIteration):
+        await builtins.anext(results)
+    assert response == {"ok": True}
+
+
+@pytest.mark.anyio
 async def test_dispatcher_streams_midstream_error() -> None:
     dispatcher = RPCDispatcher()
 


### PR DESCRIPTION
## Summary
- chain result predicates to reduce RPC dispatcher branching
- inline RPC result processing to avoid union callables and satisfy type checkers
- add postponed annotations and gate type-only imports behind `TYPE_CHECKING`
- simplify test stubs and consolidate RPC call signature alias
- factor out shared `anyio.run` stub to remove duplicate `fake_run` definitions in CLI tests
- ensure Serena tool validation only accepts actual classes
- align RPC parameter typing with client JSON aliases and prevent dict results from streaming

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a980e138e48322b35bbe994bff56ce

## Summary by Sourcery

Enforce and strengthen type annotations across core modules and tests, refactor RPC result processing for type safety, and refine Serena tool validation.

Bug Fixes:
- Prevent dict return values from being treated as streamable iterables by RPCDispatcher

Enhancements:
- Gate type-only imports behind TYPE_CHECKING and enable postponed annotation evaluation
- Replace union-based ResultProcessor logic in RPCDispatcher with a predicate-driven processor chain
- Strengthen typing for RPC handlers, parameters, and single-result processing using JSONObject alias
- Require actual class types for Serena tools and improve related error messages
- Align CLI parameter typing with JSONObject and consolidate anyio.run stubs into a shared helper

Build:
- Enable flake8 ANN rule in pyproject.toml to enforce function and method annotations

Tests:
- Add test to verify dict results from RPCDispatcher are handled as single responses
- Update CLI tests to use the shared anyio.run stub and new JSON alias types
- Add type hints to existing tests for consistency with enforced annotations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CLI now reports RPC errors clearly and exits with a non-zero status.
- Improvements
  - Consistent JSON parameter handling across CLI commands.
  - Clearer tool loading error: messages now state “not a class.”
  - RPC responses reliably support dictionary-shaped results.
- Bug Fixes
  - More robust CLI behavior when parameters are missing or invalid.
- Tests
  - Expanded coverage for CLI error handling and RPC dict results.
- Chores
  - Updated lint configuration to enforce annotation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->